### PR TITLE
Deployment auth

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -12,7 +12,7 @@ tmp_dir = "tmp"
   exclude_regex = ["_test.go"]
   exclude_unchanged = false
   follow_symlink = false
-  full_bin = "ACTLABS_HUB_LOG_LEVEL=-4 ./tmp/main"
+  full_bin = "ACTLABS_HUB_LOG_LEVEL=0 ./tmp/main"
   include_dir = []
   include_ext = ["go", "tpl", "tmpl", "html"]
   include_file = []

--- a/cmd/actlabs-hub/main.go
+++ b/cmd/actlabs-hub/main.go
@@ -21,50 +21,68 @@ func main() {
 	logger.SetupLogger()
 	appConfig, err := config.NewConfig()
 	if err != nil {
-		slog.Error("Error initializing config", err)
+		slog.Error("Error initializing config",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 
 	rdb, err := redis.NewRedisClient()
 	if err != nil {
-		slog.Error("Error initializing redis", err)
+		slog.Error("Error initializing redis",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 
 	auth, err := auth.NewAuth(appConfig)
 	if err != nil {
-		slog.Error("Error initializing auth", err)
+		slog.Error("Error initializing auth",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 
 	serverRepository, err := repository.NewServerRepository(appConfig, auth, rdb)
 	if err != nil {
-		slog.Error("Error initializing server repository", err)
+		slog.Error("Error initializing server repository",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 	labRepository, err := repository.NewLabRepository(auth, appConfig, rdb)
 	if err != nil {
-		slog.Error("Error initializing lab repository", err)
+		slog.Error("Error initializing lab repository",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 	assignmentRepository, err := repository.NewAssignmentRepository(auth, appConfig, rdb)
 	if err != nil {
-		slog.Error("Error initializing assignment repository", err)
+		slog.Error("Error initializing assignment repository",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 	challengeRepository, err := repository.NewChallengeRepository(auth, appConfig, rdb)
 	if err != nil {
-		slog.Error("Error initializing challenge repository", err)
+		slog.Error("Error initializing challenge repository",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 	authRepository, err := repository.NewAuthRepository(auth, appConfig, rdb)
 	if err != nil {
-		slog.Error("Error initializing auth repository", err)
+		slog.Error("Error initializing auth repository",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 	deploymentRepository, err := repository.NewDeploymentRepository(auth, rdb)
 	if err != nil {
-		slog.Error("Error initializing deployment repository", err)
+		slog.Error("Error initializing deployment repository",
+			slog.String("error", err.Error()),
+		)
 		panic(err)
 	}
 

--- a/deploy/deploy.template.yaml
+++ b/deploy/deploy.template.yaml
@@ -64,6 +64,8 @@ properties:
             value: ${ACTLABS_HUB_PROFILES_TABLE_NAME}
           - name: ACTLABS_HUB_DEPLOYMENTS_TABLE_NAME
             value: ${ACTLABS_HUB_DEPLOYMENTS_TABLE_NAME}
+          - name: ACTLABS_HUB_DEPLOYMENT_OPERATIONS_TABLE_NAME
+            value: ${ACTLABS_HUB_DEPLOYMENT_OPERATIONS_TABLE_NAME}
           - name: ACTLABS_HUB_CLIENT_ID
             value: ${ACTLABS_HUB_CLIENT_ID}
           - name: ACTLABS_HUB_USE_MSI

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Auth struct {
-	Cred                          azcore.TokenCredential
-	ActlabsServersTableClient     *aztables.Client
-	ActlabsReadinessTableClient   *aztables.Client
-	ActlabsChallengesTableClient  *aztables.Client
-	ActlabsProfilesTableClient    *aztables.Client
-	ActlabsDeploymentsTableClient *aztables.Client
-	StorageAccountKey             string
+	Cred                                   azcore.TokenCredential
+	ActlabsServersTableClient              *aztables.Client
+	ActlabsReadinessTableClient            *aztables.Client
+	ActlabsChallengesTableClient           *aztables.Client
+	ActlabsProfilesTableClient             *aztables.Client
+	ActlabsDeploymentsTableClient          *aztables.Client
+	ActlabSDeploymentOperationsTableClient *aztables.Client
+	StorageAccountKey                      string
 }
 
 func NewAuth(appConfig *config.Config) (*Auth, error) {
@@ -94,14 +95,24 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 		return nil, fmt.Errorf("not able to create table client %w", err)
 	}
 
+	actlabsDeploymentOperationsTableClient, err := GetTableClient(
+		accountKey,
+		appConfig.ActlabsHubStorageAccount,
+		appConfig.ActlabsHubDeploymentOperationsTableName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("not able to create table client %w", err)
+	}
+
 	return &Auth{
-		Cred:                          cred,
-		StorageAccountKey:             accountKey,
-		ActlabsServersTableClient:     actlabsServersTableClient,
-		ActlabsReadinessTableClient:   actlabsReadinessTableClient,
-		ActlabsChallengesTableClient:  actlabsChallengesTableClient,
-		ActlabsProfilesTableClient:    actlabsProfilesTableClient,
-		ActlabsDeploymentsTableClient: actlabsDeploymentsTableClient,
+		Cred:                                   cred,
+		StorageAccountKey:                      accountKey,
+		ActlabsServersTableClient:              actlabsServersTableClient,
+		ActlabsReadinessTableClient:            actlabsReadinessTableClient,
+		ActlabsChallengesTableClient:           actlabsChallengesTableClient,
+		ActlabsProfilesTableClient:             actlabsProfilesTableClient,
+		ActlabsDeploymentsTableClient:          actlabsDeploymentsTableClient,
+		ActlabSDeploymentOperationsTableClient: actlabsDeploymentOperationsTableClient,
 	}, nil
 }
 

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -131,14 +131,18 @@ func GetTokenJSON(token string) (map[string]interface{}, error) {
 	tokenParts := strings.Split(token, ".")
 	if len(tokenParts) < 2 {
 		err := errors.New("invalid token format")
-		slog.Error("invalid token format", err)
+		slog.Error("invalid token format",
+			slog.String("error", err.Error()),
+		)
 		return map[string]interface{}{}, err
 	}
 
 	// Decode the token
 	decodedToken, err := base64.URLEncoding.DecodeString(tokenParts[1] + strings.Repeat("=", (4-len(tokenParts[1])%4)%4))
 	if err != nil {
-		slog.Error("not able to decode token -> ", err)
+		slog.Error("not able to decode token -> ",
+			slog.String("error", err.Error()),
+		)
 		return map[string]interface{}{}, err
 	}
 
@@ -146,7 +150,9 @@ func GetTokenJSON(token string) (map[string]interface{}, error) {
 	var tokenJSON map[string]interface{}
 	err = json.Unmarshal(decodedToken, &tokenJSON)
 	if err != nil {
-		slog.Error("not able to unmarshal token -> ", err)
+		slog.Error("not able to unmarshal token -> ",
+			slog.String("error", err.Error()),
+		)
 		return map[string]interface{}{}, err
 	}
 
@@ -164,7 +170,9 @@ func GetUserPrincipalFromToken(token string) (string, error) {
 	userPrincipal, ok := tokenJSON["upn"].(string)
 	if !ok {
 		err := errors.New("user principal name not found in token")
-		slog.Error("user principal name not found in token", err)
+		slog.Error("user principal name not found in token",
+			slog.String("error", err.Error()),
+		)
 		return "", err
 	}
 
@@ -182,7 +190,9 @@ func GetUserObjectIdFromToken(token string) (string, error) {
 	userObjectId, ok := tokenJSON["oid"].(string)
 	if !ok {
 		err := errors.New("user object id not found in token")
-		slog.Error("user object id not found in token", err)
+		slog.Error("user object id not found in token",
+			slog.String("error", err.Error()),
+		)
 		return "", err
 	}
 
@@ -198,44 +208,6 @@ func VerifyUserPrincipalName(userPrincipalName string, token string) bool {
 	userPrincipalNameInToken, _ := GetUserPrincipalFromToken(token)
 	return userPrincipalName == userPrincipalNameInToken
 }
-
-// func VerifyArmToken(tokenString string) (bool, error) {
-// 	tokenJSON, err := GetTokenJSON(tokenString)
-// 	if err != nil {
-// 		return false, err
-// 	}
-
-// 	// check the audience
-// 	aud, ok := tokenJSON["aud"].(string)
-// 	if !ok {
-// 		return false, errors.New("not able to get audience from claims")
-// 	}
-
-// 	if aud != "https://management.core.windows.net/" {
-// 		return false, errors.New("unexpected audience, expected https://management.core.windows.net/ but got " + aud)
-// 	}
-
-// 	// Check the issuer
-// 	iss, ok := tokenJSON["iss"].(string)
-// 	if !ok {
-// 		return false, errors.New("not able to get issuer from claims")
-// 	}
-
-// 	if iss != "https://sts.windows.net/"+os.Getenv("TENANT_ID")+"/" {
-// 		return false, errors.New("unexpected issuer, expected https://sts.windows.net/" + os.Getenv("TENANT_ID") + "/ but got " + iss)
-// 	}
-
-// 	// Check the expiration time
-// 	exp, ok := tokenJSON["exp"].(float64)
-// 	if !ok {
-// 		return false, errors.New("invalid expiration time")
-// 	}
-// 	if time.Now().Unix() > int64(exp) {
-// 		return false, errors.New("token has expired")
-// 	}
-
-// 	return true, nil
-// }
 
 func VerifyArmToken(tokenString string) (bool, error) {
 
@@ -280,34 +252,3 @@ func VerifyArmToken(tokenString string) (bool, error) {
 
 	return true, nil
 }
-
-// func GetUserPrincipalNameByMSIPrincipalID(msiPrincipalID string) (string, error) {
-// 	// Get the user principal name from the MSI principal ID
-// 	var userPrincipalName string
-
-// 	pager := a.ActlabsServersTableClient.NewListEntitiesPager(&aztables.ListEntitiesOptions{
-// 		Filter: to.Ptr("managedIdentityPrincipalId eq '" + msiPrincipalID + "'"),
-// 	})
-
-// 	for pager.More() {
-// 		resp, err := pager.NextPage(context.Background())
-// 		if err != nil {
-// 			slog.Error("not able to get next page", slog.String("error", err.Error()))
-// 			return "", err
-// 		}
-
-// 		for _, entity := range resp.Entities {
-// 			var myEntity aztables.EDMEntity
-// 			err := json.Unmarshal(entity, &myEntity)
-// 			if err != nil {
-// 				slog.Error("not able to unmarshal entity", slog.String("error", err.Error()))
-// 				return "", err
-// 			}
-
-// 			userPrincipalName := myEntity.Properties["userPrincipalName"].(string)
-// 			return userPrincipalName, nil
-// 		}
-// 	}
-
-// 	return userPrincipalName, errors.New("not able to find user principal name for msi principal id " + msiPrincipalID)
-// }

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -255,8 +255,8 @@ func VerifyArmToken(tokenString string) (bool, error) {
 	if !ok {
 		return false, errors.New("not able to get audience from claims")
 	}
-	if aud != "https://management.azure.com" {
-		return false, errors.New("unexpected audience, expected https://management.azure.com but got " + aud)
+	if aud != "https://management.azure.com" && aud != "https://management.core.windows.net/" {
+		return false, errors.New("unexpected audience, expected https://management.azure.com or https://management.core.windows.net/ but got " + aud)
 	}
 
 	// Check the issuer

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -170,7 +170,7 @@ func GetUserPrincipalFromToken(token string) (string, error) {
 	userPrincipal, ok := tokenJSON["upn"].(string)
 	if !ok {
 		err := errors.New("user principal name not found in token")
-		slog.Error("user principal name not found in token",
+		slog.Debug("user principal name not found in token",
 			slog.String("error", err.Error()),
 		)
 		return "", err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	ActlabsHubChallengesTableName                  string
 	ActlabsHubProfilesTableName                    string
 	ActlabsHubDeploymentsTableName                 string
+	ActlabsHubDeploymentOperationsTableName        string
 	ActlabsHubResourceGroup                        string
 	ActlabsHubStorageAccount                       string
 	ActlabsHubSubscriptionID                       string
@@ -210,6 +211,11 @@ func NewConfig() (*Config, error) {
 		return nil, fmt.Errorf("ACTLABS_HUB_DEPLOYMENTS_TABLE_NAME not set")
 	}
 
+	actlabsHubDeploymentOperationsTableName := getEnv("ACTLABS_HUB_DEPLOYMENT_OPERATIONS_TABLE_NAME")
+	if actlabsHubDeploymentOperationsTableName == "" {
+		return nil, fmt.Errorf("ACTLABS_HUB_DEPLOYMENT_OPERATIONS_TABLE_NAME not set")
+	}
+
 	actlabsHubAutoDestroyPollingIntervalSeconds, err := strconv.ParseInt(getEnvWithDefault("ACTLABS_HUB_AUTO_DESTROY_POLLING_INTERVAL_SECONDS", "600"), 10, 32)
 	if err != nil {
 		return nil, err
@@ -234,6 +240,7 @@ func NewConfig() (*Config, error) {
 		ActlabsHubChallengesTableName:                  actlabsHubChallengesTableName,
 		ActlabsHubProfilesTableName:                    actlabsHubProfilesTableName,
 		ActlabsHubDeploymentsTableName:                 actlabsHubDeploymentsTableName,
+		ActlabsHubDeploymentOperationsTableName:        actlabsHubDeploymentOperationsTableName,
 		ActlabsHubResourceGroup:                        actlabsHubResourceGroup,
 		ActlabsHubStorageAccount:                       actlabsHubStorageAccount,
 		ActlabsHubSubscriptionID:                       actlabsHubSubscriptionID,

--- a/internal/entity/deployment.go
+++ b/internal/entity/deployment.go
@@ -62,6 +62,9 @@ type DeploymentService interface {
 	DeleteDeployment(ctx context.Context, userPrincipalName string, subscriptionId string, workspace string) error
 
 	MonitorAndDeployAutoDestroyedServersToDestroyPendingDeployments(ctx context.Context)
+
+	// may be this function doesn't belong here. but right now no other service needs this so keeping it here
+	GetUserPrincipalNameByMSIPrincipalID(ctx context.Context, msiPrincipalID string) (string, error)
 }
 
 type DeploymentRepository interface {
@@ -71,4 +74,7 @@ type DeploymentRepository interface {
 	UpsertDeployment(ctx context.Context, deployment Deployment) error
 	DeploymentOperationEntry(ctx context.Context, deployment Deployment) error
 	DeleteDeployment(ctx context.Context, userPrincipalName string, subscriptionId string, workspace string) error
+
+	// may be this function doesn't belong here. but right now no other service needs this so keeping it here
+	GetUserPrincipalNameByMSIPrincipalID(ctx context.Context, msiPrincipalID string) (string, error)
 }

--- a/internal/entity/server.go
+++ b/internal/entity/server.go
@@ -13,7 +13,6 @@ const (
 	ServerStatusDeployed      ServerStatus = "Deployed"
 	ServerStatusDeploying     ServerStatus = "Deploying"
 	ServerStatusDestroyed     ServerStatus = "Destroyed"
-	ServerSTatusDestroying    ServerStatus = "Destroying"
 	ServerStatusFailed        ServerStatus = "Failed"
 	ServerStatusRegistered    ServerStatus = "Registered"
 	ServerStatusRunning       ServerStatus = "Running"

--- a/internal/handler/deployment.go
+++ b/internal/handler/deployment.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"net/http"
 
 	"actlabs-hub/internal/auth"
@@ -25,9 +27,10 @@ func NewDeploymentHandler(r *gin.RouterGroup, service entity.DeploymentService) 
 }
 
 func (d *deploymentHandler) GetUserDeployments(c *gin.Context) {
-	userPrincipal, err := auth.GetUserPrincipalFromToken(c.GetHeader("Authorization"))
+	userPrincipal, err := GetUserPrincipalFromToken(c.Request.Context(), d.deploymentService, c.GetHeader("Authorization"))
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid access token"})
+		return
 	}
 
 	deployments, err := d.deploymentService.GetUserDeployments(c.Request.Context(), userPrincipal)
@@ -46,9 +49,10 @@ func (d *deploymentHandler) UpsertDeployment(c *gin.Context) {
 		return
 	}
 
-	userPrincipal, err := auth.GetUserPrincipalFromToken(c.GetHeader("Authorization"))
+	userPrincipal, err := GetUserPrincipalFromToken(c.Request.Context(), d.deploymentService, c.GetHeader("Authorization"))
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid access token"})
+		return
 	}
 
 	deployment.DeploymentId = userPrincipal + "-" + deployment.DeploymentWorkspace + "-" + deployment.DeploymentSubscriptionId
@@ -66,9 +70,10 @@ func (d *deploymentHandler) DeleteDeployment(c *gin.Context) {
 	subscriptionId := c.Param("subscriptionId")
 	workspace := c.Param("workspace")
 
-	userPrincipal, err := auth.GetUserPrincipalFromToken(c.GetHeader("Authorization"))
+	userPrincipal, err := GetUserPrincipalFromToken(c.Request.Context(), d.deploymentService, c.GetHeader("Authorization"))
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid access token"})
+		return
 	}
 
 	if err := d.deploymentService.DeleteDeployment(c.Request.Context(), userPrincipal, workspace, subscriptionId); err != nil {
@@ -76,4 +81,29 @@ func (d *deploymentHandler) DeleteDeployment(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+func GetUserPrincipalFromToken(ctx context.Context, d entity.DeploymentService, token string) (string, error) {
+	userPrincipal, err := auth.GetUserPrincipalFromToken(token)
+	if err != nil && userPrincipal == "" {
+		slog.Debug("no user principal found in token checking if it is an MSI token")
+
+		oid, err := auth.GetUserObjectIdFromToken(token)
+		if err != nil {
+			return "", errors.New("invalid access token")
+		}
+
+		userPrincipal, err := d.GetUserPrincipalNameByMSIPrincipalID(ctx, oid)
+		if err != nil {
+			return "", errors.New("invalid access token")
+		}
+
+		if userPrincipal == "" {
+			return "", errors.New("invalid access token")
+		}
+
+		return userPrincipal, nil
+	}
+
+	return userPrincipal, nil
 }

--- a/internal/handler/deployment.go
+++ b/internal/handler/deployment.go
@@ -77,7 +77,7 @@ func (d *deploymentHandler) DeleteDeployment(c *gin.Context) {
 	}
 
 	if err := d.deploymentService.DeleteDeployment(c.Request.Context(), userPrincipal, workspace, subscriptionId); err != nil {
-		slog.Error("error deleting deployment ", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 	}
 
 	c.Status(http.StatusNoContent)

--- a/internal/handler/lab.go
+++ b/internal/handler/lab.go
@@ -9,6 +9,7 @@ import (
 	"actlabs-hub/internal/entity"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/exp/slog"
 )
 
 type labHandler struct {
@@ -66,6 +67,12 @@ func (l *labHandler) GetLab(c *gin.Context) {
 
 	protectedLabSecret := c.Request.Header.Get("ProtectedLabSecret")
 	if protectedLabSecret != l.appConfig.ProtectedLabSecret {
+		slog.Error("invalid protected lab secret",
+			slog.String("labId", labId),
+			slog.String("typeOfLab", typeOfLab),
+			slog.String("protectedLabSecret", protectedLabSecret),
+		)
+
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Protected lab secret is invalid."})
 		return
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -16,7 +16,9 @@ func SetupLogger() {
 
 	logLevelInt, err := strconv.Atoi(logLevel)
 	if err != nil {
-		slog.Error("Error converting ACTLABS_HUB_LOG_LEVEL to int will default to 0", err)
+		slog.Error("Error converting ACTLABS_HUB_LOG_LEVEL to int will default to 0",
+			slog.String("error", err.Error()),
+		)
 		logLevelInt = 0
 	}
 

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -147,6 +147,7 @@ func ContributorRequired(authService entity.AuthService) gin.HandlerFunc {
 func verifyAccessToken(c *gin.Context, accessToken string) error {
 	splitToken := strings.Split(accessToken, "Bearer ")
 	if len(splitToken) < 2 {
+		slog.Error("found something in the Authorization header, but it's not a bearer token")
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return errors.New("found something in the Authorization header, but it's not a bearer token")
 	}

--- a/internal/repository/assignment.go
+++ b/internal/repository/assignment.go
@@ -32,6 +32,7 @@ func NewAssignmentRepository(
 }
 
 func (a *assignmentRepository) GetAllAssignments() ([]entity.Assignment, error) {
+	slog.Debug("getting all assignments")
 	assignment := entity.Assignment{}
 	assignments := []entity.Assignment{}
 
@@ -39,14 +40,18 @@ func (a *assignmentRepository) GetAllAssignments() ([]entity.Assignment, error) 
 	for pager.More() {
 		response, err := pager.NextPage(context.Background())
 		if err != nil {
-			slog.Error("Error getting entities: ", err)
+			slog.Debug("error getting assignments entities",
+				slog.String("error", err.Error()),
+			)
 			return assignments, err
 		}
 
 		for _, element := range response.Entities {
 			//var myEntity aztables.EDMEntity
 			if err := json.Unmarshal(element, &assignment); err != nil {
-				slog.Error("Error unmarshal entity: ", err)
+				slog.Debug("error unmarshal entity",
+					slog.String("error", err.Error()),
+				)
 				return assignments, err
 			}
 			assignments = append(assignments, assignment)
@@ -57,6 +62,9 @@ func (a *assignmentRepository) GetAllAssignments() ([]entity.Assignment, error) 
 }
 
 func (a *assignmentRepository) GetAssignmentsByLabId(labId string) ([]entity.Assignment, error) {
+	slog.Debug("getting assignments by lab id",
+		slog.String("labId", labId),
+	)
 	assignment := entity.Assignment{}
 	assignments := []entity.Assignment{}
 
@@ -64,14 +72,20 @@ func (a *assignmentRepository) GetAssignmentsByLabId(labId string) ([]entity.Ass
 	for pager.More() {
 		response, err := pager.NextPage(context.Background())
 		if err != nil {
-			slog.Error("Error getting entities: ", err)
+			slog.Debug("error getting entities",
+				slog.String("labId", labId),
+				slog.String("error", err.Error()),
+			)
 			return assignments, err
 		}
 
 		for _, element := range response.Entities {
 			//var myEntity aztables.EDMEntity
 			if err := json.Unmarshal(element, &assignment); err != nil {
-				slog.Error("Error unmarshal entity: ", err)
+				slog.Debug("error unmarshal entity",
+					slog.String("labId", labId),
+					slog.String("error", err.Error()),
+				)
 				return assignments, err
 			}
 
@@ -85,6 +99,10 @@ func (a *assignmentRepository) GetAssignmentsByLabId(labId string) ([]entity.Ass
 }
 
 func (a *assignmentRepository) GetAssignmentsByUserId(userId string) ([]entity.Assignment, error) {
+	slog.Debug("getting assignments by user id",
+		slog.String("userId", userId),
+	)
+
 	assignment := entity.Assignment{}
 	assignments := []entity.Assignment{}
 
@@ -92,14 +110,20 @@ func (a *assignmentRepository) GetAssignmentsByUserId(userId string) ([]entity.A
 	for pager.More() {
 		response, err := pager.NextPage(context.Background())
 		if err != nil {
-			slog.Error("Error getting entities: ", err)
+			slog.Debug("error getting entities",
+				slog.String("userId", userId),
+				slog.String("error", err.Error()),
+			)
 			return assignments, err
 		}
 
 		for _, element := range response.Entities {
 			//var myEntity aztables.EDMEntity
 			if err := json.Unmarshal(element, &assignment); err != nil {
-				slog.Error("Error unmarshal entity: ", err)
+				slog.Debug("error unmarshal entity",
+					slog.String("userId", userId),
+					slog.String("error", err.Error()),
+				)
 				return assignments, err
 			}
 
@@ -114,39 +138,56 @@ func (a *assignmentRepository) GetAssignmentsByUserId(userId string) ([]entity.A
 
 func (a *assignmentRepository) DeleteAssignment(assignmentId string) error {
 
-	slog.Debug("Deleting assignment: ", assignmentId)
+	slog.Debug("deleting assignment",
+		slog.String("assignmentId", assignmentId),
+	)
 
 	userId := assignmentId[:strings.Index(assignmentId, "+")]
 
 	_, err := a.auth.ActlabsReadinessTableClient.DeleteEntity(context.Background(), userId, assignmentId, nil)
 	if err != nil {
-		slog.Error("Error deleting assignment record: ", err)
+		slog.Debug("error deleting assignment record: ",
+			slog.String("assignmentId", assignmentId),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
-	slog.Debug("Assignment record deleted successfully")
+
 	return nil
 }
 
 func (a *assignmentRepository) UpsertAssignment(assignment entity.Assignment) error {
+	slog.Debug("upserting assignment",
+		slog.String("assignmentId", assignment.AssignmentId),
+		slog.String("userId", assignment.UserId),
+		slog.String("labId", assignment.LabId),
+	)
+
 	assignment.PartitionKey = assignment.UserId
 	assignment.RowKey = assignment.AssignmentId
 
 	val, err := json.Marshal(assignment)
 	if err != nil {
-		slog.Error("Error marshalling assignment record: ", err)
+		slog.Error("error marshalling assignment record",
+			slog.String("assignmentId", assignment.AssignmentId),
+			slog.String("userId", assignment.UserId),
+			slog.String("labId", assignment.LabId),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
-
-	slog.Debug("Assignment record: ", string(val))
 
 	_, err = a.auth.ActlabsReadinessTableClient.UpsertEntity(context.TODO(), val, nil)
 
 	if err != nil {
-		slog.Error("Error creating assignment record: ", err)
+		slog.Error("error creating assignment record: ",
+			slog.String("assignmentId", assignment.AssignmentId),
+			slog.String("userId", assignment.UserId),
+			slog.String("labId", assignment.LabId),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
-
-	slog.Debug("Assignment record created successfully")
 
 	return nil
 }

--- a/internal/repository/assignment.go
+++ b/internal/repository/assignment.go
@@ -168,7 +168,7 @@ func (a *assignmentRepository) UpsertAssignment(assignment entity.Assignment) er
 
 	val, err := json.Marshal(assignment)
 	if err != nil {
-		slog.Error("error marshalling assignment record",
+		slog.Debug("error marshalling assignment record",
 			slog.String("assignmentId", assignment.AssignmentId),
 			slog.String("userId", assignment.UserId),
 			slog.String("labId", assignment.LabId),
@@ -180,7 +180,7 @@ func (a *assignmentRepository) UpsertAssignment(assignment entity.Assignment) er
 	_, err = a.auth.ActlabsReadinessTableClient.UpsertEntity(context.TODO(), val, nil)
 
 	if err != nil {
-		slog.Error("error creating assignment record: ",
+		slog.Debug("error creating assignment record: ",
 			slog.String("assignmentId", assignment.AssignmentId),
 			slog.String("userId", assignment.UserId),
 			slog.String("labId", assignment.LabId),

--- a/internal/repository/challenge.go
+++ b/internal/repository/challenge.go
@@ -32,6 +32,8 @@ func NewChallengeRepository(
 }
 
 func (c *challengeRepository) GetAllChallenges() ([]entity.Challenge, error) {
+	slog.Debug("getting all challenges")
+
 	challenge := entity.Challenge{}
 	challenges := []entity.Challenge{}
 
@@ -39,14 +41,18 @@ func (c *challengeRepository) GetAllChallenges() ([]entity.Challenge, error) {
 	for pager.More() {
 		response, err := pager.NextPage(context.Background())
 		if err != nil {
-			slog.Error("Error getting entities: ", err)
+			slog.Debug("error getting entities",
+				slog.String("error", err.Error()),
+			)
 			return challenges, err
 		}
 
 		for _, element := range response.Entities {
 			//var myEntity aztables.EDMEntity
 			if err := json.Unmarshal(element, &challenge); err != nil {
-				slog.Error("Error unmarshal entity: ", err)
+				slog.Debug("error unmarshal entity",
+					slog.String("error", err.Error()),
+				)
 				return challenges, err
 			}
 			challenges = append(challenges, challenge)
@@ -57,6 +63,10 @@ func (c *challengeRepository) GetAllChallenges() ([]entity.Challenge, error) {
 }
 
 func (c *challengeRepository) GetChallengesByLabId(labId string) ([]entity.Challenge, error) {
+	slog.Debug("getting challenges by lab id",
+		slog.String("labId", labId),
+	)
+
 	challenge := entity.Challenge{}
 	challenges := []entity.Challenge{}
 
@@ -64,14 +74,20 @@ func (c *challengeRepository) GetChallengesByLabId(labId string) ([]entity.Chall
 	for pager.More() {
 		response, err := pager.NextPage(context.Background())
 		if err != nil {
-			slog.Error("Error getting entities: ", err)
+			slog.Debug("error getting entities",
+				slog.String("labId", labId),
+				slog.String("error", err.Error()),
+			)
 			return challenges, err
 		}
 
 		for _, element := range response.Entities {
 			//var myEntity aztables.EDMEntity
 			if err := json.Unmarshal(element, &challenge); err != nil {
-				slog.Error("Error unmarshal entity: ", err)
+				slog.Debug("error unmarshal entity",
+					slog.String("labId", labId),
+					slog.String("error", err.Error()),
+				)
 				return challenges, err
 			}
 			challenges = append(challenges, challenge)
@@ -82,6 +98,10 @@ func (c *challengeRepository) GetChallengesByLabId(labId string) ([]entity.Chall
 }
 
 func (c *challengeRepository) GetChallengesByUserId(userId string) ([]entity.Challenge, error) {
+	slog.Debug("getting challenges by user id",
+		slog.String("userId", userId),
+	)
+
 	challenge := entity.Challenge{}
 	challenges := []entity.Challenge{}
 
@@ -89,14 +109,18 @@ func (c *challengeRepository) GetChallengesByUserId(userId string) ([]entity.Cha
 	for pager.More() {
 		response, err := pager.NextPage(context.Background())
 		if err != nil {
-			slog.Error("Error getting entities: ", err)
+			slog.Debug("error getting entities: ",
+				slog.String("userId", userId),
+			)
 			return challenges, err
 		}
 
 		for _, element := range response.Entities {
 			//var myEntity aztables.EDMEntity
 			if err := json.Unmarshal(element, &challenge); err != nil {
-				slog.Error("Error unmarshal entity: ", err)
+				slog.Debug("error unmarshal entity: ",
+					slog.String("userId", userId),
+				)
 				return challenges, err
 			}
 
@@ -110,22 +134,30 @@ func (c *challengeRepository) GetChallengesByUserId(userId string) ([]entity.Cha
 }
 
 func (c *challengeRepository) DeleteChallenge(challengeId string) error {
-
-	slog.Debug("Deleting challenge: " + challengeId)
+	slog.Debug("deleting challenge",
+		slog.String("challengeId", challengeId),
+	)
 
 	userId := strings.SplitN(challengeId, "+", 2)[1]
 
 	_, err := c.auth.ActlabsChallengesTableClient.DeleteEntity(context.Background(), userId, challengeId, nil)
 	if err != nil {
-		slog.Error("Error deleting challenge: ", err)
+		slog.Debug("error deleting challenge",
+			slog.String("challengeId", challengeId),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
-	slog.Debug("Deleted challenge: " + challengeId)
 
 	return nil
 }
 
 func (c *challengeRepository) UpsertChallenge(challenge entity.Challenge) error {
+	slog.Debug("upserting challenge",
+		slog.String("challengeId", challenge.ChallengeId),
+		slog.String("userId", challenge.UserId),
+		slog.String("labId", challenge.LabId),
+	)
 
 	if challenge.ChallengeId == "" {
 		challenge.ChallengeId = uuid.NewString()
@@ -136,17 +168,25 @@ func (c *challengeRepository) UpsertChallenge(challenge entity.Challenge) error 
 
 	val, err := json.Marshal(challenge)
 	if err != nil {
-		slog.Error("Error marshalling challenge: ", err)
+		slog.Debug("error marshalling challenge",
+			slog.String("challengeId", challenge.ChallengeId),
+			slog.String("userId", challenge.UserId),
+			slog.String("labId", challenge.LabId),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
 
 	_, err = c.auth.ActlabsChallengesTableClient.UpsertEntity(context.Background(), val, nil)
 	if err != nil {
-		slog.Error("Error updating/creating challenge: ", err)
+		slog.Debug("error updating/creating challenge",
+			slog.String("challengeId", challenge.ChallengeId),
+			slog.String("userId", challenge.UserId),
+			slog.String("labId", challenge.LabId),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
-
-	slog.Debug("Challenge updated/created successfully")
 
 	return nil
 }

--- a/internal/repository/deployment.go
+++ b/internal/repository/deployment.go
@@ -3,11 +3,13 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"actlabs-hub/internal/auth"
 	"actlabs-hub/internal/entity"
 	"actlabs-hub/internal/helper"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/exp/slog"
@@ -257,7 +259,7 @@ func (d *deploymentRepository) UpsertDeployment(ctx context.Context, deployment 
 		return err
 	}
 
-	_, err = d.auth.ActlabsDeploymentsTableClient.UpsertEntity(context.TODO(), marshalled, nil)
+	_, err = d.auth.ActlabsDeploymentsTableClient.UpsertEntity(ctx, marshalled, nil)
 	if err != nil {
 		slog.Debug("error adding deployment record ",
 			slog.String("userId", deployment.DeploymentUserId),
@@ -341,7 +343,7 @@ func (d *deploymentRepository) DeploymentOperationEntry(ctx context.Context, dep
 		return err
 	}
 
-	_, err = d.auth.ActlabsDeploymentsTableClient.UpsertEntity(context.TODO(), marshalled, nil)
+	_, err = d.auth.ActlabSDeploymentOperationsTableClient.UpsertEntity(ctx, marshalled, nil)
 	if err != nil {
 		slog.Debug("error adding deployment entry record ",
 			slog.String("userId", deployment.DeploymentUserId),
@@ -379,5 +381,62 @@ func (d *deploymentRepository) DeleteDeployment(ctx context.Context, userId stri
 		return err
 	}
 
+	// delete deployments for user from redis
+	if err := d.rdb.Del(ctx, userId+"-deployments").Err(); err != nil {
+		slog.Debug("error occurred deleting the deployments record from redis.",
+			slog.String("userId", userId),
+			slog.String("subscriptionId", subscriptionId),
+			slog.String("workspace", workspace),
+			slog.String("error", err.Error()),
+		)
+
+		return err
+	}
+
 	return nil
+}
+
+func (d *deploymentRepository) GetUserPrincipalNameByMSIPrincipalID(ctx context.Context, msiPrincipalID string) (string, error) {
+	// check the cache first
+	userPrincipalName, err := d.rdb.Get(ctx, msiPrincipalID+"-owner").Result()
+	if err == nil && userPrincipalName != "" {
+		return userPrincipalName, nil
+	}
+
+	slog.Debug("not able to find user principal name for msi principal id in redis, continue to get from table storage")
+
+	pager := d.auth.ActlabsServersTableClient.NewListEntitiesPager(&aztables.ListEntitiesOptions{
+		Filter: to.Ptr("managedIdentityPrincipalId eq '" + msiPrincipalID + "'"),
+	})
+
+	for pager.More() {
+		resp, err := pager.NextPage(ctx)
+		if err != nil {
+			slog.Error("not able to get next page", slog.String("error", err.Error()))
+			return "", err
+		}
+
+		for _, entity := range resp.Entities {
+			var myEntity aztables.EDMEntity
+			err := json.Unmarshal(entity, &myEntity)
+			if err != nil {
+				slog.Error("not able to unmarshal entity", slog.String("error", err.Error()))
+				return "", err
+			}
+
+			userPrincipalName := myEntity.Properties["userPrincipalName"].(string)
+			return userPrincipalName, nil
+		}
+	}
+
+	// save user principal name to redis
+	if err := d.rdb.Set(ctx, msiPrincipalID+"-owner", userPrincipalName, 0).Err(); err != nil {
+		slog.Debug("error occurred saving the user principal name record to redis.",
+			slog.String("msiPrincipalID", msiPrincipalID),
+			slog.String("userPrincipalName", userPrincipalName),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	return userPrincipalName, errors.New("not able to find user principal name for msi principal id " + msiPrincipalID)
 }

--- a/internal/repository/deployment.go
+++ b/internal/repository/deployment.go
@@ -185,20 +185,35 @@ func (d *deploymentRepository) GetDeployment(ctx context.Context, userId string,
 
 	response, err := d.auth.ActlabsDeploymentsTableClient.GetEntity(ctx, userId, userId+"-"+subscriptionId+"-"+workspace, nil)
 	if err != nil {
-		slog.Error("error getting deployment ", err)
+		slog.Debug("error getting deployment ",
+			slog.String("userId", userId),
+			slog.String("subscriptionId", subscriptionId),
+			slog.String("workspace", workspace),
+			slog.String("error", err.Error()),
+		)
 		return entity.Deployment{}, err
 	}
 
 	var myEntity aztables.EDMEntity
 	err = json.Unmarshal(response.Value, &myEntity)
 	if err != nil {
-		slog.Error("error unmarshal deployment entity ", err)
+		slog.Debug("error unmarshal deployment entity ",
+			slog.String("userId", userId),
+			slog.String("subscriptionId", subscriptionId),
+			slog.String("workspace", workspace),
+			slog.String("error", err.Error()),
+		)
 		return entity.Deployment{}, err
 	}
 
 	deploymentString = myEntity.Properties["Deployment"].(string)
 	if err := json.Unmarshal([]byte(deploymentString), &deployment); err != nil {
-		slog.Error("error unmarshal deployment ", err)
+		slog.Debug("error unmarshal deployment ",
+			slog.String("userId", userId),
+			slog.String("subscriptionId", subscriptionId),
+			slog.String("workspace", workspace),
+			slog.String("error", err.Error()),
+		)
 		return entity.Deployment{}, err
 	}
 
@@ -412,7 +427,7 @@ func (d *deploymentRepository) GetUserPrincipalNameByMSIPrincipalID(ctx context.
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {
-			slog.Error("not able to get next page", slog.String("error", err.Error()))
+			slog.Debug("not able to get next page", slog.String("error", err.Error()))
 			return "", err
 		}
 
@@ -420,7 +435,7 @@ func (d *deploymentRepository) GetUserPrincipalNameByMSIPrincipalID(ctx context.
 			var myEntity aztables.EDMEntity
 			err := json.Unmarshal(entity, &myEntity)
 			if err != nil {
-				slog.Error("not able to unmarshal entity", slog.String("error", err.Error()))
+				slog.Debug("not able to unmarshal entity", slog.String("error", err.Error()))
 				return "", err
 			}
 

--- a/internal/repository/lab.go
+++ b/internal/repository/lab.go
@@ -97,12 +97,12 @@ func (l *labRepository) ListBlobs(
 	// save the blobs in redis
 	blobsBytes, err := json.Marshal(blobs)
 	if err != nil {
-		slog.Error("not able to marshal blobs", slog.String("error", err.Error()))
+		slog.Debug("not able to marshal blobs", slog.String("error", err.Error()))
 		return blobs, nil
 	}
 	blobsStr = string(blobsBytes)
 	if err := l.rdb.Set(ctx, "blobs-"+labType, blobsStr, 0).Err(); err != nil {
-		slog.Error("not able to set blobs in redis", slog.String("error", err.Error()))
+		slog.Debug("not able to set blobs in redis", slog.String("error", err.Error()))
 		return blobs, nil
 	}
 
@@ -185,12 +185,12 @@ func (l *labRepository) GetLabWithVersions(ctx context.Context, typeOfLab string
 	// add labs to redis
 	labsBytes, err := json.Marshal(labs)
 	if err != nil {
-		slog.Error("not able to marshal labs", slog.String("error", err.Error()))
+		slog.Debug("not able to marshal labs", slog.String("error", err.Error()))
 		return labs, nil
 	}
 
 	if err := l.rdb.Set(ctx, redisKey("labWithVersions", typeOfLab, appendDotJson(labId)), string(labsBytes), 0).Err(); err != nil {
-		slog.Error("not able to set lab with versions in redis",
+		slog.Debug("not able to set lab with versions in redis",
 			slog.String("error", err.Error()),
 			slog.String("labId", labId),
 		)
@@ -236,7 +236,7 @@ func (l *labRepository) GetLab(
 
 	// save the lab in redis
 	if err := l.rdb.Set(ctx, redisKey("lab", typeOfLab, appendDotJson(labId)), string(actualBlobData), 0).Err(); err != nil {
-		slog.Error("not able to set lab in redis", slog.String("error", err.Error()))
+		slog.Debug("not able to set lab in redis", slog.String("error", err.Error()))
 	}
 
 	if err := json.Unmarshal(actualBlobData, &lab); err != nil {

--- a/internal/repository/server.go
+++ b/internal/repository/server.go
@@ -341,10 +341,6 @@ func (s *serverRepository) DeployAzureContainerGroup(server entity.Server) (enti
 									Value: to.Ptr(strconv.FormatBool(s.appConfig.ActlabsServerUseMsi)),
 								},
 								{
-									Name:  to.Ptr("PROTECTED_LAB_SECRET"),
-									Value: to.Ptr(s.appConfig.ProtectedLabSecret),
-								},
-								{
 									Name:  to.Ptr("ACTLABS_HUB_URL"),
 									Value: to.Ptr(s.appConfig.ActlabsHubURL),
 								},

--- a/internal/service/assignment.go
+++ b/internal/service/assignment.go
@@ -23,6 +23,8 @@ func NewAssignmentService(assignmentRepository entity.AssignmentRepository, labS
 }
 
 func (a *assignmentService) GetAllAssignments() ([]entity.Assignment, error) {
+	slog.Info("getting all assignments")
+
 	assignments, err := a.assignmentRepository.GetAllAssignments()
 	if err != nil {
 		slog.Error("not able to get assignments",
@@ -34,6 +36,10 @@ func (a *assignmentService) GetAllAssignments() ([]entity.Assignment, error) {
 }
 
 func (a *assignmentService) GetAssignmentsByLabId(labId string) ([]entity.Assignment, error) {
+	slog.Info("getting assignments for lab",
+		slog.String("labId", labId),
+	)
+
 	assignments, err := a.assignmentRepository.GetAssignmentsByLabId(labId)
 	if err != nil {
 		slog.Error("not able to get assignments for lab",
@@ -46,6 +52,10 @@ func (a *assignmentService) GetAssignmentsByLabId(labId string) ([]entity.Assign
 }
 
 func (a *assignmentService) GetAssignmentsByUserId(userId string) ([]entity.Assignment, error) {
+	slog.Info("getting assignments for user",
+		slog.String("userId", userId),
+	)
+
 	assignments, err := a.assignmentRepository.GetAssignmentsByUserId(userId)
 	if err != nil {
 		slog.Error("not able to get assignments for user ",
@@ -58,6 +68,7 @@ func (a *assignmentService) GetAssignmentsByUserId(userId string) ([]entity.Assi
 }
 
 func (a *assignmentService) GetAllLabsRedacted() ([]entity.LabType, error) {
+	slog.Info("getting all labs redacted")
 	readinessLabRedacted := []entity.LabType{}
 
 	labs, err := a.labService.GetProtectedLabs("readinesslab")
@@ -80,6 +91,10 @@ func (a *assignmentService) GetAllLabsRedacted() ([]entity.LabType, error) {
 }
 
 func (a *assignmentService) GetAssignedLabsRedactedByUserId(userId string) ([]entity.LabType, error) {
+	slog.Info("getting all labs redacted by user",
+		slog.String("userId", userId),
+	)
+
 	assignedLabs := []entity.LabType{}
 
 	assignments, err := a.GetAssignmentsByUserId(userId)
@@ -119,6 +134,7 @@ func (a *assignmentService) GetAssignedLabsRedactedByUserId(userId string) ([]en
 }
 
 func (a *assignmentService) CreateAssignments(userIds []string, labIds []string, createdBy string) error {
+
 	for _, userId := range userIds {
 
 		if !strings.Contains(userId, "@microsoft.com") {
@@ -143,6 +159,10 @@ func (a *assignmentService) CreateAssignments(userIds []string, labIds []string,
 		}
 
 		for _, labId := range labIds {
+			slog.Info("creating assignment",
+				slog.String("userId", userId),
+				slog.String("labId", labId),
+			)
 
 			assignment := entity.Assignment{
 				PartitionKey: userId,
@@ -169,6 +189,9 @@ func (a *assignmentService) CreateAssignments(userIds []string, labIds []string,
 }
 
 func (a *assignmentService) DeleteAssignments(assignmentIds []string) error {
+	slog.Info("deleting assignments",
+		slog.String("assignmentIds", strings.Join(assignmentIds, ",")),
+	)
 	for _, assignmentId := range assignmentIds {
 		if err := a.assignmentRepository.DeleteAssignment(assignmentId); err != nil {
 			slog.Error("not able to delete assignment",

--- a/internal/service/assignment.go
+++ b/internal/service/assignment.go
@@ -70,7 +70,7 @@ func (a *assignmentService) GetAllLabsRedacted() ([]entity.LabType, error) {
 
 	for _, lab := range labs {
 		lab.ExtendScript = "redacted"
-		lab.Description = "<p>" + lab.Name + "</p>"
+		lab.Description = "<p>" + lab.Name + "</p>" // keep in p tags for UI to render correctly
 		lab.Type = "assignment"
 		lab.Tags = []string{"assignment"}
 		readinessLabRedacted = append(readinessLabRedacted, lab)

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -19,6 +19,9 @@ func NewAuthService(authRepository entity.AuthRepository) entity.AuthService {
 }
 
 func (s *AuthService) CreateProfile(profile entity.Profile) error {
+	slog.Info("creating profile",
+		slog.String("userPrincipal", profile.UserPrincipal),
+	)
 
 	existingProfile, err := s.authRepository.GetProfile(profile.UserPrincipal)
 	if err != nil {
@@ -58,6 +61,10 @@ func (s *AuthService) CreateProfile(profile entity.Profile) error {
 }
 
 func (s *AuthService) GetProfile(userPrincipal string) (entity.Profile, error) {
+	slog.Info("getting profile",
+		slog.String("userPrincipal", userPrincipal),
+	)
+
 	profile, err := s.authRepository.GetProfile(userPrincipal)
 	if err != nil {
 		slog.Error("error getting profile",
@@ -89,6 +96,7 @@ func (s *AuthService) GetAllProfilesRedacted() ([]entity.Profile, error) {
 }
 
 func (s *AuthService) GetAllProfiles() ([]entity.Profile, error) {
+	slog.Info("getting all profiles")
 	profiles, err := s.authRepository.GetAllProfiles()
 	if err != nil {
 		slog.Error("error getting profiles: ",
@@ -99,6 +107,10 @@ func (s *AuthService) GetAllProfiles() ([]entity.Profile, error) {
 }
 
 func (s *AuthService) DeleteRole(userPrincipal string, role string) error {
+	slog.Info("deleting role",
+		slog.String("userPrincipal", userPrincipal),
+		slog.String("role", role),
+	)
 
 	// Get the profile
 	profile, err := s.GetProfile(userPrincipal)
@@ -127,6 +139,11 @@ func (s *AuthService) DeleteRole(userPrincipal string, role string) error {
 }
 
 func (s *AuthService) AddRole(userPrincipal string, role string) error {
+
+	slog.Info("adding role",
+		slog.String("userPrincipal", userPrincipal),
+		slog.String("role", role),
+	)
 
 	// Get the profile
 	profile, err := s.GetProfile(userPrincipal)

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -43,7 +43,7 @@ func (s *AutoDestroyService) MonitorAndDestroyInactiveServers(ctx context.Contex
 }
 
 func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
-	slog.Debug("polling for servers to destroy")
+	slog.Info("polling for servers to destroy")
 	allServers, err := s.serverRepository.GetAllServersFromDatabase(ctx)
 	if err != nil {
 		slog.Error("not able to get all servers", err)

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -143,6 +143,7 @@ func (s *AutoDestroyService) DestroyServer(server entity.Server) error {
 		slog.String("subscriptionId", server.SubscriptionId),
 		slog.String("status", string(server.Status)),
 		slog.String("lastActivityTime", server.LastUserActivityTime),
+		slog.Duration("allowedInactiveDuration", time.Duration(server.InactivityDurationInSeconds)*time.Second),
 		slog.Bool("autoDestroy", server.AutoDestroy),
 	)
 

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -35,7 +35,9 @@ func (s *AutoDestroyService) MonitorAndDestroyInactiveServers(ctx context.Contex
 			case <-ticker.C:
 				// Every minute, check for servers to destroy
 				if err := s.DestroyIdleServers(ctx); err != nil {
-					slog.Error("not able to destroy idle servers", err)
+					slog.Error("not able to destroy idle servers",
+						slog.String("error", err.Error()),
+					)
 				}
 			}
 		}
@@ -46,7 +48,9 @@ func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
 	slog.Info("polling for servers to destroy")
 	allServers, err := s.serverRepository.GetAllServersFromDatabase(ctx)
 	if err != nil {
-		slog.Error("not able to get all servers", err)
+		slog.Error("not able to get all servers",
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
 
@@ -54,7 +58,9 @@ func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
 
 		lastActivityTime, err := time.Parse(time.RFC3339, server.LastUserActivityTime)
 		if err != nil {
-			slog.Error("not able to parse last activity time", err)
+			slog.Error("not able to parse last activity time",
+				slog.String("error", err.Error()),
+			)
 			continue
 		}
 
@@ -98,7 +104,9 @@ func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
 func (s *AutoDestroyService) VerifyServerIdle(server entity.Server) bool {
 	isIdle, err := s.serverRepository.EnsureServerIdle(server)
 	if err != nil {
-		slog.Error("not able to verify server idle", err)
+		slog.Error("not able to verify server idle",
+			slog.String("error", err.Error()),
+		)
 		return false
 	}
 

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -88,6 +88,17 @@ func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
 			server.Status == entity.ServerStatusRunning &&
 			time.Since(lastActivityTime) > time.Duration(server.InactivityDurationInSeconds)*time.Second &&
 			s.VerifyServerIdle(server) {
+
+			slog.Info("destroying server",
+				slog.String("userPrincipalName", server.UserPrincipalName),
+				slog.String("subscriptionId", server.SubscriptionId),
+				slog.String("status", string(server.Status)),
+				slog.Bool("autoDestroy", server.AutoDestroy),
+				slog.String("lastActivityTime", server.LastUserActivityTime),
+				slog.Duration("timeSinceLastActivity", time.Since(lastActivityTime)),
+				slog.Duration("inactiveDuration", time.Duration(server.InactivityDurationInSeconds)*time.Second),
+			)
+
 			if err := s.DestroyServer(server); err != nil {
 				return err
 			}
@@ -115,15 +126,6 @@ func (s *AutoDestroyService) VerifyServerIdle(server entity.Server) bool {
 }
 
 func (s *AutoDestroyService) DestroyServer(server entity.Server) error {
-	slog.Info("destroying server",
-		slog.String("userPrincipalName", server.UserPrincipalName),
-		slog.String("subscriptionId", server.SubscriptionId),
-		slog.String("status", string(server.Status)),
-		slog.String("lastActivityTime", server.LastUserActivityTime),
-		slog.Duration("allowedInactiveDuration", time.Duration(server.InactivityDurationInSeconds)*time.Second),
-		slog.Bool("autoDestroy", server.AutoDestroy),
-	)
-
 	if err := s.serverRepository.DestroyAzureContainerGroup(server); err != nil {
 
 		slog.Error("not able to destroy server",

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -85,7 +85,9 @@ func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
 		}
 
 		if server.AutoDestroy &&
-			server.Status == entity.ServerStatusRunning &&
+			server.Status != entity.ServerStatusAutoDestroyed &&
+			server.Status != entity.ServerStatusDestroyed &&
+			server.Status != entity.ServerStatusUnregistered &&
 			time.Since(lastActivityTime) > time.Duration(server.InactivityDurationInSeconds)*time.Second &&
 			s.VerifyServerIdle(server) {
 

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -119,11 +119,12 @@ func (s *AutoDestroyService) VerifyServerIdle(server entity.Server) bool {
 }
 
 func (s *AutoDestroyService) DestroyServer(server entity.Server) error {
-	slog.Debug("destroying server",
+	slog.Info("destroying server",
 		slog.String("userPrincipalName", server.UserPrincipalName),
 		slog.String("subscriptionId", server.SubscriptionId),
 		slog.String("status", string(server.Status)),
 		slog.String("lastActivityTime", server.LastUserActivityTime),
+		slog.Duration("allowedInactiveDuration", time.Duration(server.InactivityDurationInSeconds)*time.Second),
 		slog.Bool("autoDestroy", server.AutoDestroy),
 	)
 
@@ -137,15 +138,6 @@ func (s *AutoDestroyService) DestroyServer(server entity.Server) error {
 	if err := s.serverRepository.UpsertServerInDatabase(server); err != nil {
 		return err
 	}
-
-	slog.Info("server destroyed",
-		slog.String("userPrincipalName", server.UserPrincipalName),
-		slog.String("subscriptionId", server.SubscriptionId),
-		slog.String("status", string(server.Status)),
-		slog.String("lastActivityTime", server.LastUserActivityTime),
-		slog.Duration("allowedInactiveDuration", time.Duration(server.InactivityDurationInSeconds)*time.Second),
-		slog.Bool("autoDestroy", server.AutoDestroy),
-	)
 
 	return nil
 }

--- a/internal/service/deployment.go
+++ b/internal/service/deployment.go
@@ -207,13 +207,6 @@ func (d *DeploymentService) RedeployServer(ctx context.Context, deployment entit
 
 	if server.Status == entity.ServerStatusAutoDestroyed &&
 		server.SubscriptionId == deployment.DeploymentSubscriptionId {
-		slog.Info("redeploying auto destroyed server to destroy the deployment",
-			slog.String("userPrincipalName", deployment.DeploymentUserId),
-			slog.String("subscriptionId", deployment.DeploymentSubscriptionId),
-			slog.String("deploymentWorkspace", deployment.DeploymentWorkspace),
-			slog.String("labName", deployment.DeploymentLab.Name),
-		)
-
 		// deploy server again.
 		server, err := d.serverService.DeployServer(server)
 		if err != nil {

--- a/internal/service/deployment.go
+++ b/internal/service/deployment.go
@@ -158,7 +158,7 @@ func (d *DeploymentService) MonitorAndDeployAutoDestroyedServersToDestroyPending
 }
 
 func (d *DeploymentService) PollDeploymentsToBeAutoDestroyed(ctx context.Context) error {
-	slog.Info("polling for deployments to deploy")
+	slog.Info("polling for deployments to be destroyed")
 	allDeployments, err := d.deploymentRepository.GetAllDeployments(ctx)
 	if err != nil {
 		slog.Error("not able to get all deployments", err)
@@ -203,9 +203,11 @@ func (d *DeploymentService) RedeployServer(ctx context.Context, deployment entit
 
 	if server.Status == entity.ServerStatusAutoDestroyed &&
 		server.SubscriptionId == deployment.DeploymentSubscriptionId {
-		slog.Debug("deploying auto destroyed server",
+		slog.Info("redeploying auto destroyed server to destroy the deployment",
 			slog.String("userPrincipalName", deployment.DeploymentUserId),
 			slog.String("subscriptionId", deployment.DeploymentSubscriptionId),
+			slog.String("deploymentWorkspace", deployment.DeploymentWorkspace),
+			slog.String("labName", deployment.DeploymentLab.Name),
 		)
 
 		// deploy server again.

--- a/internal/service/deployment.go
+++ b/internal/service/deployment.go
@@ -43,7 +43,7 @@ func (d *DeploymentService) GetAllDeployments(ctx context.Context) ([]entity.Dep
 }
 
 func (d *DeploymentService) GetUserDeployments(ctx context.Context, usePrincipalName string) ([]entity.Deployment, error) {
-	slog.Debug("getting user deployments",
+	slog.Info("getting user deployments",
 		slog.String("userPrincipalName", usePrincipalName),
 	)
 
@@ -61,7 +61,7 @@ func (d *DeploymentService) GetUserDeployments(ctx context.Context, usePrincipal
 }
 
 func (d *DeploymentService) GetDeployment(ctx context.Context, usePrincipalName string, workspace string, subscriptionId string) (entity.Deployment, error) {
-	slog.Debug("getting deployment",
+	slog.Info("getting deployment",
 		slog.String("userPrincipalName", usePrincipalName),
 		slog.String("workspace", workspace),
 		slog.String("subscriptionId", subscriptionId),
@@ -83,7 +83,7 @@ func (d *DeploymentService) GetDeployment(ctx context.Context, usePrincipalName 
 }
 
 func (d *DeploymentService) UpsertDeployment(ctx context.Context, deployment entity.Deployment) error {
-	slog.Debug("upserting deployment",
+	slog.Info("upserting deployment",
 		slog.String("userPrincipalName", deployment.DeploymentUserId),
 		slog.String("deploymentWorkspace", deployment.DeploymentWorkspace),
 		slog.String("subscriptionId", deployment.DeploymentSubscriptionId),
@@ -107,7 +107,7 @@ func (d *DeploymentService) UpsertDeployment(ctx context.Context, deployment ent
 }
 
 func (d *DeploymentService) DeleteDeployment(ctx context.Context, userPrincipalName string, subscriptionId string, workspace string) error {
-	slog.Debug("deleting deployment",
+	slog.Info("deleting deployment",
 		slog.String("userPrincipalName", userPrincipalName),
 		slog.String("workspace", workspace),
 		slog.String("subscriptionId", subscriptionId),
@@ -158,7 +158,7 @@ func (d *DeploymentService) MonitorAndDeployAutoDestroyedServersToDestroyPending
 }
 
 func (d *DeploymentService) PollDeploymentsToBeAutoDestroyed(ctx context.Context) error {
-	slog.Debug("polling for deployments to deploy")
+	slog.Info("polling for deployments to deploy")
 	allDeployments, err := d.deploymentRepository.GetAllDeployments(ctx)
 	if err != nil {
 		slog.Error("not able to get all deployments", err)
@@ -243,7 +243,7 @@ func (d *DeploymentService) RedeployServer(ctx context.Context, deployment entit
 }
 
 func (d *DeploymentService) GetUserPrincipalNameByMSIPrincipalID(ctx context.Context, msiPrincipalID string) (string, error) {
-	slog.Debug("getting user principal name by msi principal id",
+	slog.Info("getting user principal name by msi principal id",
 		slog.String("msiPrincipalID", msiPrincipalID),
 	)
 

--- a/internal/service/deployment.go
+++ b/internal/service/deployment.go
@@ -150,7 +150,9 @@ func (d *DeploymentService) MonitorAndDeployAutoDestroyedServersToDestroyPending
 			case <-ticker.C:
 				// Every minute, check for servers to destroy
 				if err := d.PollDeploymentsToBeAutoDestroyed(ctx); err != nil {
-					slog.Error("not able to deploy auto destroyed servers to destroy pending deployments", err)
+					slog.Error("not able to deploy auto destroyed servers to destroy pending deployments",
+						slog.String("error", err.Error()),
+					)
 				}
 			}
 		}
@@ -161,7 +163,9 @@ func (d *DeploymentService) PollDeploymentsToBeAutoDestroyed(ctx context.Context
 	slog.Info("polling for deployments to be destroyed")
 	allDeployments, err := d.deploymentRepository.GetAllDeployments(ctx)
 	if err != nil {
-		slog.Error("not able to get all deployments", err)
+		slog.Error("not able to get all deployments",
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
 

--- a/internal/service/deployment.go
+++ b/internal/service/deployment.go
@@ -98,6 +98,11 @@ func (d *DeploymentService) UpsertDeployment(ctx context.Context, deployment ent
 
 		return err
 	}
+
+	// Add deployment operation entry
+	// sending a different context here cause http context will end early while this operation is still running.
+	go d.deploymentRepository.DeploymentOperationEntry(context.Background(), deployment)
+
 	return nil
 }
 
@@ -235,4 +240,22 @@ func (d *DeploymentService) RedeployServer(ctx context.Context, deployment entit
 			)
 		}
 	}
+}
+
+func (d *DeploymentService) GetUserPrincipalNameByMSIPrincipalID(ctx context.Context, msiPrincipalID string) (string, error) {
+	slog.Debug("getting user principal name by msi principal id",
+		slog.String("msiPrincipalID", msiPrincipalID),
+	)
+
+	userPrincipalName, err := d.deploymentRepository.GetUserPrincipalNameByMSIPrincipalID(ctx, msiPrincipalID)
+	if err != nil {
+		slog.Error("not able to get user principal name by msi principal id",
+			slog.String("msiPrincipalID", msiPrincipalID),
+			slog.String("error", err.Error()),
+		)
+
+		return "", err
+	}
+
+	return userPrincipalName, nil
 }

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -228,12 +228,10 @@ func (l *labService) GetProtectedLabVersions(typeOfLab string, labId string) ([]
 }
 
 func (l *labService) GetLabVersions(typeOfLab string, labId string) ([]entity.LabType, error) {
-	labs := []entity.LabType{}
-
 	labs, err := l.labRepository.GetLabWithVersions(context.TODO(), typeOfLab, labId)
 	if err != nil {
 		slog.Error("Not able to get list of blobs", err)
-		return labs, err
+		return []entity.LabType{}, err
 	}
 
 	return labs, nil

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -212,7 +212,9 @@ func (l *labService) DeletePrivateLab(typeOfLab string, labId string, userId str
 func (l *labService) DeletePublicLab(typeOfLab string, labId string, userId string) error {
 	ok, err := l.IsDeleteAllowed(typeOfLab, labId, userId)
 	if err != nil {
-		slog.Error("Not able to verify if delete should be allowed or not", err)
+		slog.Error("Not able to verify if delete should be allowed or not",
+			slog.String("error", err.Error()),
+		)
 	}
 
 	if !ok {
@@ -229,7 +231,9 @@ func (l *labService) DeleteProtectedLab(typeOfLab string, labId string) error {
 
 func (l *labService) DeleteLab(typeOfLab string, labId string) error {
 	if err := l.labRepository.DeleteLab(context.TODO(), typeOfLab, labId); err != nil {
-		slog.Error("not able to delete lab", err)
+		slog.Error("not able to delete lab",
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
 	return nil
@@ -238,7 +242,9 @@ func (l *labService) DeleteLab(typeOfLab string, labId string) error {
 func (l *labService) GetPrivateLabVersions(typeOfLab string, labId string, userId string) ([]entity.LabType, error) {
 	existingLab, err := l.labRepository.GetLab(context.TODO(), typeOfLab, labId)
 	if err != nil {
-		slog.Error("Not able to get the current version of lab.", err)
+		slog.Error("Not able to get the current version of lab.",
+			slog.String("error", err.Error()),
+		)
 		return []entity.LabType{}, err
 	}
 	if !helper.Contains(existingLab.Owners, userId) && !helper.Contains(existingLab.Editors, userId) && !helper.Contains(existingLab.Viewers, userId) {
@@ -259,7 +265,9 @@ func (l *labService) GetProtectedLabVersions(typeOfLab string, labId string) ([]
 func (l *labService) GetLabVersions(typeOfLab string, labId string) ([]entity.LabType, error) {
 	labs, err := l.labRepository.GetLabWithVersions(context.TODO(), typeOfLab, labId)
 	if err != nil {
-		slog.Error("Not able to get list of blobs", err)
+		slog.Error("Not able to get list of blobs",
+			slog.String("error", err.Error()),
+		)
 		return []entity.LabType{}, err
 	}
 

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"actlabs-hub/internal/entity"
@@ -24,25 +25,25 @@ func NewLabService(repo entity.LabRepository) entity.LabService {
 }
 
 func (l *labService) GetAllPrivateLabs(typeOfLab string) ([]entity.LabType, error) {
-
 	if typeOfLab != "challengelab" {
-		slog.Error("Only challenge labs are allowed via this function", nil)
+		slog.Error("only challenge labs are allowed via this function",
+			slog.String("typeOfLab", typeOfLab),
+		)
 		return []entity.LabType{}, errors.New("only challenge labs are allowed via this function")
 	}
 
 	labs, err := l.GetLabs(typeOfLab)
 	if err != nil {
-		slog.Error("Not able to get private labs", err)
+		return []entity.LabType{}, err
 	}
 
 	return labs, nil
 }
 
 func (l *labService) GetPrivateLabs(typeOfLab string, userId string) ([]entity.LabType, error) {
-	// Public labs must only be shown to users who own them.
 	labs, err := l.GetLabs(typeOfLab)
 	if err != nil {
-		slog.Error("Not able to get private labs", err)
+		return labs, err
 	}
 
 	var filteredLabs []entity.LabType
@@ -64,7 +65,7 @@ func (l *labService) GetPublicLabs(typeOfLab string) ([]entity.LabType, error) {
 func (l *labService) GetProtectedLab(typeOfLab string, labId string) (entity.LabType, error) {
 	labs, err := l.GetProtectedLabs(typeOfLab)
 	if err != nil {
-		slog.Error("Not able to get protected labs", err)
+		return entity.LabType{}, err
 	}
 
 	for _, lab := range labs {
@@ -80,11 +81,18 @@ func (l *labService) GetProtectedLabs(typeOfLab string) ([]entity.LabType, error
 }
 
 func (l *labService) GetLabs(typeOfLab string) ([]entity.LabType, error) {
+	slog.Info("getting labs",
+		slog.String("typeOfLab", typeOfLab),
+	)
+
 	labs := []entity.LabType{}
 
 	blobs, err := l.labRepository.ListBlobs(context.TODO(), typeOfLab)
 	if err != nil {
-		slog.Error("Not able to get list of blobs", err)
+		slog.Error("not able to get list of blobs",
+			slog.String("typeOfLab", typeOfLab),
+			slog.String("error", err.Error()),
+		)
 		return labs, err
 	}
 
@@ -95,11 +103,11 @@ func (l *labService) GetLabs(typeOfLab string) ([]entity.LabType, error) {
 				slog.Error("not able to get blob from given url",
 					slog.String("labId", element.Name),
 					slog.String("typeOfLab", typeOfLab),
+					slog.String("error", err.Error()),
 				)
 				continue
 			}
 			AddCategoryToLabIfMissing(&lab)
-			slog.Debug("For " + lab.Type + " type, adding lab " + lab.Name + " to list of labs")
 			labs = append(labs, lab)
 		}
 	}
@@ -110,25 +118,24 @@ func (l *labService) GetLabs(typeOfLab string) ([]entity.LabType, error) {
 func (l *labService) UpsertPrivateLab(lab entity.LabType) error {
 	ok, err := l.IsUpsertAllowed(lab)
 	if err != nil {
-		slog.Error("Not able to verify if upsert is allowed or not.", err)
+		return err
 	}
 
 	if !ok {
-		slog.Error(lab.UpdatedBy+" is not either owner or editor which is required to edit the private lab.", nil)
-		return errors.New("user is not either owner or editor which is required to edit the private lab")
+		return fmt.Errorf("user is not either owner or editor which is required to edit the private lab")
 	}
+
 	return l.UpsertLab(lab)
 }
 
 func (l *labService) UpsertPublicLab(lab entity.LabType) error {
 	ok, err := l.IsUpsertAllowed(lab)
 	if err != nil {
-		slog.Error("Not able to verify if upsert is allowed or not.", err)
+		return err
 	}
 
 	if !ok {
-		slog.Error(lab.UpdatedBy+" is not either owner or editor which is required to edit the public lab.", nil)
-		return errors.New("user is not either owner or editor which is required to edit the public lab")
+		return fmt.Errorf("user is not either owner or editor which is required to edit the public lab")
 	}
 	return l.UpsertLab(lab)
 }
@@ -141,11 +148,10 @@ func (l *labService) UpsertLab(lab entity.LabType) error {
 
 	ok, err := l.ValidateAddingEditorsOrViewers(lab)
 	if err != nil {
-		slog.Error("Error validating lab", err)
+		return &json.MarshalerError{}
 	}
 
 	if !ok {
-		slog.Error("User is not an owner and there are changes in either owners, editors or viewers which is no allowed", nil)
 		return errors.New("user is not an owner and there are changes in owners, editors, or viewers")
 	}
 
@@ -154,13 +160,27 @@ func (l *labService) UpsertLab(lab entity.LabType) error {
 
 	val, err := json.Marshal(lab)
 	if err != nil {
-		slog.Error("not able to convert object to string", err)
-		return err
+		slog.Error("not able to convert object to string",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+			slog.String("editors", strings.Join(lab.Editors, ", ")),
+			slog.String("error", err.Error()),
+		)
+		return fmt.Errorf("not able to convert object to string")
 	}
 
 	if err := l.labRepository.UpsertLab(context.TODO(), lab.Id, string(val), lab.Type); err != nil {
-		slog.Error("not able to save lab", err)
-		return err
+		slog.Error("not able to save lab",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+			slog.String("editors", strings.Join(lab.Editors, ", ")),
+			slog.String("error", err.Error()),
+		)
+		return fmt.Errorf("not able to save lab")
 	}
 
 	return nil
@@ -169,15 +189,24 @@ func (l *labService) UpsertLab(lab entity.LabType) error {
 func (l *labService) DeletePrivateLab(typeOfLab string, labId string, userId string) error {
 	ok, err := l.IsDeleteAllowed(typeOfLab, labId, userId)
 	if err != nil {
-		slog.Error("Not able to verify if delete should be allowed or not", err)
+		return err
 	}
 
 	if !ok {
-		slog.Error("Only owner can delete the lab", err)
 		return errors.New("only owner can delete the lab")
 	}
 
-	return l.DeleteLab(typeOfLab, labId)
+	if err := l.DeleteLab(typeOfLab, labId); err != nil {
+		slog.Error("not able to delete lab",
+			slog.String("userId", userId),
+			slog.String("labId", labId),
+			slog.String("typeOfLab", typeOfLab),
+			slog.String("error", err.Error()),
+		)
+		return fmt.Errorf("not able to delete lab")
+	}
+
+	return nil
 }
 
 func (l *labService) DeletePublicLab(typeOfLab string, labId string, userId string) error {
@@ -282,26 +311,48 @@ func (l *labService) AssignOwnerToOrphanLab(lab *entity.LabType) {
 
 func (l *labService) ValidateAddingEditorsOrViewers(lab entity.LabType) (bool, error) {
 	if lab.Id == "" {
-		slog.Debug("New lab, all good")
+		slog.Debug("new lab, all good",
+			slog.String("labName", lab.Name),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+		)
 		return true, nil // New lab all good.
 	}
 
 	existingLab, err := l.labRepository.GetLab(context.TODO(), lab.Type, lab.Id)
 	if err != nil {
-		slog.Error("Error getting current version of lab "+lab.Name+" : ", err)
-		return false, err
+		slog.Error("error getting current version of lab",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+			slog.String("editors", strings.Join(lab.Editors, ", ")),
+			slog.String("error", err.Error()),
+		)
+		return false, fmt.Errorf("error getting current version of lab")
 	}
 
 	if len(existingLab.Owners) == 0 || (len(existingLab.Owners) == 1 && existingLab.Owners[0] == "") {
-		slog.Info("No owners specified. Allowing changes.")
+		slog.Debug("no owners specified allowing changes",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+			slog.String("editors", strings.Join(lab.Editors, ", ")),
+		)
 		return true, nil
 	}
 
 	if !helper.Contains(existingLab.Owners, lab.UpdatedBy) {
 		if !helper.SlicesAreEqual(existingLab.Owners, lab.Owners) || !helper.SlicesAreEqual(existingLab.Editors, lab.Editors) || !helper.SlicesAreEqual(existingLab.Viewers, lab.Viewers) {
-			slog.Debug("Existing Lab: ", existingLab)
-			slog.Debug("New Lab: ", lab)
-			return false, nil
+			slog.Error("user is not owner and there are changes in either owners, editors or viewers which is not allowed",
+				slog.String("labName", lab.Name),
+				slog.String("labId", lab.Id),
+				slog.String("typeOfLab", lab.Type),
+				slog.String("owners", strings.Join(lab.Owners, ", ")),
+				slog.String("editors", strings.Join(lab.Editors, ", ")),
+				slog.String("viewers", strings.Join(lab.Viewers, ", ")),
+			)
+			return false, fmt.Errorf("user is not owner and there are changes in owners, editors, or viewers")
 		}
 	}
 
@@ -310,38 +361,60 @@ func (l *labService) ValidateAddingEditorsOrViewers(lab entity.LabType) (bool, e
 
 func (l *labService) IsUpsertAllowed(lab entity.LabType) (bool, error) {
 	if lab.Id == "" {
-		slog.Debug("New lab, all good")
+		slog.Debug("New lab, all good",
+			slog.String("labName", lab.Name),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+		)
 		return true, nil // New lab all good.
 	}
 
+	// if lab is not new, we must find it in db.
 	existingLab, err := l.labRepository.GetLab(context.TODO(), lab.Type, lab.Id)
 	if err != nil {
-		slog.Error("Error getting current version of lab "+lab.Name+" : ", err)
+		slog.Error("error getting current version of lab",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+			slog.String("error", err.Error()),
+		)
 		return false, err
 	}
 
 	if len(existingLab.Owners) == 0 || (len(existingLab.Owners) == 1 && existingLab.Owners[0] == "") {
-		slog.Info("No owners specified. Allowing changes.")
+		slog.Debug("no owners specified. allowing changes",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+		)
 		return true, nil
 	}
 
 	if !helper.Contains(existingLab.Owners, lab.UpdatedBy) && !helper.Contains(existingLab.Editors, lab.UpdatedBy) {
-		return false, nil // user not either owner or editor. edit not allowed.
+		slog.Error("user is not either owner or editor which is required to edit the lab",
+			slog.String("labName", lab.Name),
+			slog.String("labId", lab.Id),
+			slog.String("typeOfLab", lab.Type),
+			slog.String("owners", strings.Join(lab.Owners, ", ")),
+			slog.String("editors", strings.Join(lab.Editors, ", ")),
+		)
+		return false, fmt.Errorf("user is not owner or editor") // user not either owner or editor. edit not allowed.
 	}
 
 	return true, nil
 }
 
 func (l *labService) IsDeleteAllowed(typeOfLab string, labId string, userId string) (bool, error) {
-	slog.Debug("Validating if user is owner of lab or not",
-		slog.String("typeOfLab", typeOfLab),
-		slog.String("labId", labId),
-		slog.String("userId", userId),
-	)
 	existingLab, err := l.labRepository.GetLab(context.TODO(), typeOfLab, labId)
 	if err != nil {
-		slog.Error("Error getting current version of lab", err)
-		return false, err
+		slog.Error("error getting current version of lab",
+			slog.String("useId", userId),
+			slog.String("labId", labId),
+			slog.String("typeOfLab", typeOfLab),
+			slog.String("error", err.Error()),
+		)
+		return false, fmt.Errorf("error getting current version of lab")
 	}
 
 	if !helper.Contains(existingLab.Owners, userId) {

--- a/internal/service/server.go
+++ b/internal/service/server.go
@@ -50,7 +50,7 @@ func (s *serverService) RegisterSubscription(subscriptionId string, userPrincipa
 }
 
 func (s *serverService) UpdateServer(server entity.Server) error {
-	slog.Debug("updating server",
+	slog.Info("updating server",
 		slog.String("userPrincipalName", server.UserPrincipalName),
 		slog.String("subscriptionId", server.SubscriptionId),
 	)
@@ -80,7 +80,7 @@ func (s *serverService) UpdateServer(server entity.Server) error {
 }
 
 func (s *serverService) DeployServer(server entity.Server) (entity.Server, error) {
-	slog.Debug("deploying server",
+	slog.Info("deploying server",
 		slog.String("userPrincipalName", server.UserPrincipalName),
 		slog.String("subscriptionId", server.SubscriptionId),
 	)
@@ -183,7 +183,7 @@ func (s *serverService) DeployServer(server entity.Server) (entity.Server, error
 }
 
 func (s *serverService) DestroyServer(userPrincipalName string) error {
-	slog.Debug("destroying server",
+	slog.Info("destroying server",
 		slog.String("userPrincipalName", userPrincipalName),
 	)
 
@@ -221,7 +221,7 @@ func (s *serverService) DestroyServer(userPrincipalName string) error {
 }
 
 func (s *serverService) GetServer(userPrincipalName string) (entity.Server, error) {
-	slog.Debug("getting server",
+	slog.Info("getting server",
 		slog.String("userPrincipalName", userPrincipalName),
 	)
 
@@ -239,7 +239,7 @@ func (s *serverService) GetServer(userPrincipalName string) (entity.Server, erro
 }
 
 func (s *serverService) UpdateActivityStatus(userPrincipalName string) error {
-	slog.Debug("updating server activity status",
+	slog.Info("updating server activity status",
 		slog.String("userPrincipalName", userPrincipalName),
 	)
 

--- a/internal/service/server.go
+++ b/internal/service/server.go
@@ -147,7 +147,7 @@ func (s *serverService) DeployServer(server entity.Server) (entity.Server, error
 	// Ensure server is up and running. check every 5 seconds for 3 minutes.
 	for i := 0; i < waitTimeSeconds/5; i++ {
 		if err := s.serverRepository.EnsureServerUp(server); err == nil {
-			slog.Info("Server is up and running",
+			slog.Info("server is up and running",
 				slog.String("userPrincipalName", server.UserPrincipalName),
 				slog.String("subscriptionId", server.SubscriptionId),
 				slog.String("status", string(server.Status)),

--- a/scripts/self-host.sh
+++ b/scripts/self-host.sh
@@ -211,8 +211,6 @@ function deploy() {
     export PORT="80"
     export ROOT_DIR="/app"
     export USE_MSI="false"
-    export AUTH_TOKEN_AUD="00399ddd-434c-4b8a-84be-d096cff4f494"
-    export AUTH_TOKEN_ISS="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0"
     export ARM_SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
     export ARM_TENANT_ID=$(az account show --query "tenantId" -o tsv)
     export ARM_USER_PRINCIPAL_NAME=$(az account show --query "user.name" -o tsv)

--- a/scripts/self-host.sh
+++ b/scripts/self-host.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+
+ACTLABS_APP_ID="bee16ca1-a401-40ee-bb6a-34349ebd993e"
+RESOURCE_GROUP="repro-project"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Function to log messages
+err() {
+    echo -e "${RED}[$(date +'%Y-%m-%dT%H:%M:%S%z')]: ERROR - $* ${NC}" >&1
+}
+
+warn() {
+    echo -e "${YELLOW}[$(date +'%Y-%m-%dT%H:%M:%S%z')]: WARNING - $* ${NC}" >&1
+}
+
+log() {
+    echo -e "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: INFO - $*" >&1
+}
+
+ok() {
+    echo -e "${GREEN}[$(date +'%Y-%m-%dT%H:%M:%S%z')]: SUCCESS - $* ${NC}" >&1
+}
+
+gap() {
+    echo >&1
+}
+
+# Function that sleeps for a specified number of seconds
+function sleep_with_progress() {
+    local TOTAL_SECONDS=$1
+    local MESSAGE=$2 # optional; if provided, will be printed before the countdown
+
+    # Check if TOTAL_SECONDS is a positive integer
+    if ! [[ "$TOTAL_SECONDS" =~ ^[0-9]+$ ]]; then
+        log "Error: Invalid number of seconds"
+        exit 1
+    fi
+
+    if [[ -n "${MESSAGE}" ]]; then
+        log "${MESSAGE}"
+    fi
+
+    local MINUTES=$((TOTAL_SECONDS / 60))
+    local SECONDS_REMAINING=$((TOTAL_SECONDS % 60))
+    log "Sleeping for ${MINUTES} minutes and ${SECONDS_REMAINING} seconds..."
+
+    while [[ ${TOTAL_SECONDS} -gt 0 ]]; do
+        MINUTES=$((TOTAL_SECONDS / 60))
+        SECONDS_REMAINING=$((TOTAL_SECONDS % 60))
+        log "${MINUTES} minutes and ${SECONDS_REMAINING} seconds remaining"
+        sleep 10
+        TOTAL_SECONDS=$((TOTAL_SECONDS - 10))
+    done
+}
+
+# Function to handle errors
+handle_error() {
+    err "$1"
+    exit 1
+}
+
+# Function to get upn of the logged in user
+get_upn() {
+    UPN=$(az ad signed-in-user show --query userPrincipalName -o tsv)
+    log "UPN: $UPN"
+
+    # drop the domain name from the upn
+    if [[ "${UPN}" == *"fdpo.onmicrosoft.com"* ]]; then
+        # USER_ALIAS=${UPN%%_*}
+        handle_error "We currently do not support Microsoft Non-Prod Tenant. Please reach out to the team for support."
+    else
+        USER_ALIAS=${UPN%%@*}
+    fi
+    log "USER_ALIAS: $USER_ALIAS"
+
+    USER_ALIAS_FOR_SA=${USER_ALIAS#v-}
+    log "USER_ALIAS_FOR_SA: $USER_ALIAS_FOR_SA"
+}
+
+# Function to get the subscription id
+get_subscription_id() {
+    SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+    log "SUBSCRIPTION_ID: $SUBSCRIPTION_ID"
+}
+
+# Function to ensure that user is the owner of the subscription
+ensure_user_is_owner() {
+    # Check if the user is the owner of the subscription
+    USER_ROLE=$(az role assignment list --assignee "${UPN}" --scope "/subscriptions/${SUBSCRIPTION_ID}" --query "[?roleDefinitionName=='Owner'].roleDefinitionName" -o tsv)
+
+    if [[ -n "${USER_ROLE}" ]]; then
+        log "user ${UPN} is the owner of the subscription"
+    else
+        err "user ${UPN} is not the owner of the subscription"
+        exit 1
+    fi
+
+    return 0
+}
+
+# Function to check if a resource group exists
+# If the resource group doesn't exist, create one
+function create_resource_group() {
+    # Check if the resource group exists
+    RG_EXISTS=$(az group exists --name "${RESOURCE_GROUP}" --output tsv)
+
+    if [[ "${RG_EXISTS}" == "true" ]]; then
+        log "resource group ${RESOURCE_GROUP} already exists"
+        return 0
+    else
+        log "creating resource group with name ${RESOURCE_GROUP}"
+
+        # Ask the user for a location if one wasn't provided
+        if [[ -z "${LOCATION}" ]]; then
+            gap
+            LOCATION=$(az account list-locations --query "[?metadata.regionType!='Logical' && metadata.physicalLocation!=null].name" -o tsv)
+            echo "Please select a location (azure region) from the list below:"
+            select LOCATION in ${LOCATION}; do
+                if [[ -n "${LOCATION}" ]]; then
+                    break
+                else
+                    echo "Invalid selection, please try again"
+                fi
+            done
+        fi
+
+        # Create the resource group
+        az group create --name "${RESOURCE_GROUP}" --location "${LOCATION}"
+        if [ $? -ne 0 ]; then
+            err "failed to create resource group ${RESOURCE_GROUP}"
+            exit 1
+        else
+            log "resource group ${RESOURCE_GROUP} created"
+        fi
+    fi
+
+    return 0
+}
+
+# Function to check if a storage account exists in the resource group
+# If the storage account doesn't exist, create one with a random name
+function create_storage_account() {
+    # Check if the storage account exists in the resource group
+    SA_EXISTS=$(az storage account list --resource-group "${RESOURCE_GROUP}" --query "[].name" -o tsv)
+
+    if [[ -n "${SA_EXISTS}" ]]; then
+        log "storage account already exists with name ${SA_EXISTS}"
+        STORAGE_ACCOUNT_NAME="$SA_EXISTS"
+    else
+        # Generate a random name for the storage account
+        RANDOM_NAME=$(openssl rand -hex 4)
+        STORAGE_ACCOUNT_NAME="${USER_ALIAS_FOR_SA}sa${RANDOM_NAME}"
+
+        log "creating storage account with name ${STORAGE_ACCOUNT_NAME} in resource group ${RESOURCE_GROUP}"
+        # Create the storage account
+        az storage account create --name "${STORAGE_ACCOUNT_NAME}" --resource-group "${RESOURCE_GROUP}" --sku Standard_LRS
+        if [ $? -ne 0 ]; then
+            err "failed to create storage account ${STORAGE_ACCOUNT_NAME}"
+            exit 1
+        else
+            log "storage account ${STORAGE_ACCOUNT_NAME} created"
+        fi
+    fi
+
+    # get storage account key
+    STORAGE_ACCOUNT_KEY=$(az storage account keys list --resource-group "${RESOURCE_GROUP}" --account-name "${STORAGE_ACCOUNT_NAME}" --query "[0].value" -o tsv)
+
+    # check if a blob container named 'tfstate' exists in the storage account
+    # if not create one
+    log "checking if blob container tfstate exists in storage account ${STORAGE_ACCOUNT_NAME}"
+    CONTAINER_EXISTS=$(az storage container exists --name "tfstate" --account-name "${STORAGE_ACCOUNT_NAME}" --account-key "${STORAGE_ACCOUNT_KEY}" --query "exists" -o tsv)
+    if [[ "${CONTAINER_EXISTS}" == "true" ]]; then
+        log "Blob container tfstate already exists in storage account ${STORAGE_ACCOUNT_NAME}"
+    else
+        log "Blob container tfstate does not exist in storage account ${STORAGE_ACCOUNT_NAME}, creating"
+        az storage container create --name "tfstate" --account-name "${STORAGE_ACCOUNT_NAME}"
+        if [ $? -ne 0 ]; then
+            err "Failed to create blob container tfstate in storage account ${STORAGE_ACCOUNT_NAME}"
+            exit 1
+        else
+            log "Blob container tfstate created in storage account ${STORAGE_ACCOUNT_NAME}"
+        fi
+    fi
+
+    # check if a blob container named 'labs' exists in the storage account
+    # if not create one
+    log "checking if blob container labs exists in storage account ${STORAGE_ACCOUNT_NAME}"
+    CONTAINER_EXISTS=$(az storage container exists --name "labs" --account-name "${STORAGE_ACCOUNT_NAME}" --account-key "${STORAGE_ACCOUNT_KEY}" --query "exists" -o tsv)
+    if [[ "${CONTAINER_EXISTS}" == "true" ]]; then
+        log "Blob container labs already exists in storage account ${STORAGE_ACCOUNT_NAME}"
+    else
+        log "Blob container labs does not exist in storage account ${STORAGE_ACCOUNT_NAME}, creating"
+        az storage container create --name "labs" --account-name "${STORAGE_ACCOUNT_NAME}"
+        if [ $? -ne 0 ]; then
+            err "Failed to create blob container labs in storage account ${STORAGE_ACCOUNT_NAME}"
+            exit 1
+        else
+            log "Blob container labs created in storage account ${STORAGE_ACCOUNT_NAME}"
+        fi
+    fi
+
+    return 0
+}
+
+function deploy() {
+    # Environment Variables
+    export PORT="80"
+    export ROOT_DIR="/app"
+    export USE_MSI="false"
+    export AUTH_TOKEN_AUD="00399ddd-434c-4b8a-84be-d096cff4f494"
+    export AUTH_TOKEN_ISS="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0"
+    export ARM_SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
+    export ARM_TENANT_ID=$(az account show --query "tenantId" -o tsv)
+    export ARM_USER_PRINCIPAL_NAME=$(az account show --query "user.name" -o tsv)
+    export AZURE_CLIENT_ID="not-used-for-self-hosting"
+    export AZURE_SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
+    export AUTH_TOKEN_ISS="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0"
+    export AUTH_TOKEN_AUD="00399ddd-434c-4b8a-84be-d096cff4f494"
+
+    # Start docker container and set environment variables
+    log "starting docker container"
+    docker run --pull=always -d --restart unless-stopped -it \
+        -e PORT \
+        -e ROOT_DIR \
+        -e USE_MSI \
+        -e LOG_LEVEL \
+        -e ARM_SUBSCRIPTION_ID \
+        -e ARM_TENANT_ID \
+        -e ARM_USER_PRINCIPAL_NAME \
+        -e AZURE_CLIENT_ID \
+        -e AZURE_SUBSCRIPTION_ID \
+        -e AUTH_TOKEN_AUD \
+        -e AUTH_TOKEN_ISS \
+        --name actlabs -p 8880:80 -v ${HOME}/.azure:/root/.azure ashishvermapu/repro:${TAG}
+    if [ $? -ne 0 ]; then
+        err "Failed to start docker container"
+        exit 1
+    fi
+
+    return 0
+}
+
+function verify() {
+    # Verify that the application is running
+    log "verifying that the application is running"
+    curl --silent --fail --show-error --max-time 10 --retry 30 --retry-delay 10 http://localhost:8880/status >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        err "Failed to verify that the application is running"
+        exit 1
+    fi
+    ok "All done! You can now access the application at https://actlabs.azureedge.net/. Your server's endpoint is http://localhost:8880/"
+
+    return 0
+}
+
+# gather input parameters
+# -t tag
+# -d debug
+
+while getopts ":t:d" opt; do
+    case $opt in
+    t)
+        TAG=$OPTARG
+        ;;
+    d)
+        DEBUG=true
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        ;;
+    esac
+done
+
+# delete existing docker container
+log "deleting existing docker container"
+docker rm -f actlabs
+
+if [ -z "${TAG}" ]; then
+    TAG="latest"
+fi
+
+if [ ${DEBUG} ]; then
+    export LOG_LEVEL="-4"
+else
+    export LOG_LEVEL="0"
+fi
+
+log "TAG = ${TAG}"
+log "DEBUG = ${DEBUG}"
+
+# Call the functions
+get_upn
+get_subscription_id
+ensure_user_is_owner
+create_resource_group
+create_storage_account
+deploy
+sleep_with_progress 10 "Waiting for the application to start"
+verify


### PR DESCRIPTION
This pull request includes various changes to improve logging, error handling, and debugging capabilities in different parts of the codebase. The most important changes include:

* <a href="diffhunk://#diff-be241c70ad0087c60b43b6c42d383dad49ad16b4d1bbd57f539ec5cf5d3496d9L22-L67">`internal/service/auth.go`</a>: Added additional logging and error handling in the `AuthService` struct. <a href="diffhunk://#diff-be241c70ad0087c60b43b6c42d383dad49ad16b4d1bbd57f539ec5cf5d3496d9L22-L67">[1]</a> <a href="diffhunk://#diff-be241c70ad0087c60b43b6c42d383dad49ad16b4d1bbd57f539ec5cf5d3496d9L110-R170">[2]</a> <a href="diffhunk://#diff-be241c70ad0087c60b43b6c42d383dad49ad16b4d1bbd57f539ec5cf5d3496d9L84-L98">[3]</a>
* <a href="diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6R26-R84">`internal/service/assignment.go`</a>: Added logging statements and error message updates in the `assignmentService` struct, and added a loop for validation checks in the `CreateAssignments` function. <a href="diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6R26-R84">[1]</a> <a href="diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6R94-L93">[2]</a> <a href="diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6L141-R200">[3]</a> <a href="diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6R137">[4]</a> <a href="diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6L118-R165">[5]</a>
* <a href="diffhunk://#diff-5ccee50bedd0a08c31591865ba4f1492577328fd78372057bb7d1aca534c2b40R399-R457">`internal/repository/deployment.go`</a>: Added a new method to delete deployments from Redis, a method to retrieve user principal name, handling errors with the addition of the "errors" package, using the correct client for the deployment operations table, replacing `context.TODO()` with `ctx`, and improved logging for error messages. <a href="diffhunk://#diff-5ccee50bedd0a08c31591865ba4f1492577328fd78372057bb7d1aca534c2b40R399-R457">[1]</a> <a href="diffhunk://#diff-5ccee50bedd0a08c31591865ba4f1492577328fd78372057bb7d1aca534c2b40R6-R12">[2]</a> <a href="diffhunk://#diff-5ccee50bedd0a08c31591865ba4f1492577328fd78372057bb7d1aca534c2b40L344-R361">[3]</a> <a href="diffhunk://#diff-5ccee50bedd0a08c31591865ba4f1492577328fd78372057bb7d1aca534c2b40L260-R277">[4]</a> <a href="diffhunk://#diff-5ccee50bedd0a08c31591865ba4f1492577328fd78372057bb7d1aca534c2b40L186-R216">[5]</a>
* <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL202-L239">`internal/auth/token.go`</a>: Various changes to improve code readability, error logging, and troubleshooting in the `token` package. <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL202-L239">[1]</a> <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL185-R195">[2]</a> <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL167-R175">[3]</a> <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL258-R231">[4]</a> <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL134-R155">[5]</a> <a href="diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dL283-L313">[6]</a>
* <a href="diffhunk://#diff-9b88aafe72a7a3fa3537b3722fa3d9f51785190ee4cc424c52cb51e937ec4d32R35-R55">`internal/repository/challenge.go`</a>: Added logging statements to the `challengeRepository` struct to improve error logging when marshalling challenges. <a href="diffhunk://#diff-9b88aafe72a7a3fa3537b3722fa3d9f51785190ee4cc424c52cb51e937ec4d32R35-R55">[1]</a> <a href="diffhunk://#diff-9b88aafe72a7a3fa3537b3722fa3d9f51785190ee4cc424c52cb51e937ec4d32R66-R90">[2]</a> <a href="diffhunk://#diff-9b88aafe72a7a3fa3537b3722fa3d9f51785190ee4cc424c52cb51e937ec4d32R101-R123">[3]</a> <a href="diffhunk://#diff-9b88aafe72a7a3fa3537b3722fa3d9f51785190ee4cc424c52cb51e937ec4d32L113-R160">[4]</a> <a href="diffhunk://#diff-9b88aafe72a7a3fa3537b3722fa3d9f51785190ee4cc424c52cb51e937ec4d32L139-L150">[5]</a>

Other changes:

* <a href="diffhunk://#diff-034a44bcefb9435dc47586022c568138be8bc4ca5f98edff87b4b49ee9d897c8L49-R55">`internal/handler/deployment.go`</a>: Handle errors and improve retrieval of user principal from the token. <a href="diffhunk://#diff-034a44bcefb9435dc47586022c568138be8bc4ca5f98edff87b4b49ee9d897c8L49-R55">[1]</a> <a href="diffhunk://#diff-034a44bcefb9435dc47586022c568138be8bc4ca5f98edff87b4b49ee9d897c8R4-R5">[2]</a> <a href="diffhunk://#diff-034a44bcefb9435dc47586022c568138be8bc4ca5f98edff87b4b49ee9d897c8L28-R33">[3]</a> <a href="diffhunk://#diff-034a44bcefb9435dc47586022c568138be8bc4ca5f98edff87b4b49ee9d897c8L69-R109">[4]</a>
* <a href="diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR214-R218">`internal/config/config.go`</a>: Add a new environment variable to the `config.go` file. <a href="diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR214-R218">[1]</a> <a href="diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR19">[2]</a> <a href="diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR243">[3]</a>
* <a href="diffhunk://#diff-686bf1c28b7f93841338199e02e03ed12f96fea2e717a8ce80eb80d44b7c09baL19-R21">`internal/logger/logger.go`</a>: Modify the `SetupLogger` function to include the error message when converting the log level to an integer.
* <a href="diffhunk://#diff-b8be380453ffd8780196f5929311a8a6fc8be5ef5af99ecf6e370ce6b03fbf3aR65-R67">`internal/entity/deployment.go`</a>: Add new functions to get the user principal name by the MSI principal ID. <a href="diffhunk://#diff-b8be380453ffd8780196f5929311a8a6fc8be5ef5af99ecf6e370ce6b03fbf3aR65-R67">[1]</a> <a href="diffhunk://#diff-b8be380453ffd8780196f5929311a8a6fc8be5ef5af99ecf6e370ce6b03fbf3aR77-R79">[2]</a>

Note: Due to the number of changes, only the most important ones have been listed here.