### PR TITLE
Assignments reporting

### DIFF
--- a/cmd/actlabs-hub/main.go
+++ b/cmd/actlabs-hub/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	handler.NewHealthzHandler(authRouter.Group("/"))
 	handler.NewServerHandler(authRouter.Group("/"), serverService)
-	handler.NewAssignmentHandler(authRouter.Group("/"), assignmentService)
+	handler.NewAssignmentHandler(authRouter.Group("/"), assignmentService, appConfig)
 	handler.NewChallengeHandler(authRouter.Group("/"), challengeService)
 	handler.NewAuthHandler(authRouter.Group("/"), authService)
 

--- a/internal/entity/assignment.go
+++ b/internal/entity/assignment.go
@@ -1,14 +1,28 @@
 package entity
 
+type AssignmentStatus = string
+
+const (
+	AssignmentStatusCreated    AssignmentStatus = "Created"
+	AssignmentStatusCompleted  AssignmentStatus = "Completed"
+	AssignmentStatusCancelled  AssignmentStatus = "Cancelled"
+	AssignmentStatusInProgress AssignmentStatus = "InProgress"
+	AssignmentStatusDeleted    AssignmentStatus = "Deleted"
+)
+
 type Assignment struct {
-	PartitionKey string `json:"PartitionKey"`
-	RowKey       string `json:"RowKey"`
-	AssignmentId string `json:"assignmentId"`
-	UserId       string `json:"userId"`
-	LabId        string `json:"labId"`
-	CreatedBy    string `json:"createdBy"`
-	CreatedOn    string `json:"createdOn"`
-	Status       string `json:"status"`
+	PartitionKey string           `json:"PartitionKey"`
+	RowKey       string           `json:"RowKey"`
+	AssignmentId string           `json:"assignmentId"`
+	UserId       string           `json:"userId"`
+	LabId        string           `json:"labId"`
+	CreatedBy    string           `json:"createdBy"`
+	DeletedBy    string           `json:"deletedBy"`
+	CreatedAt    string           `json:"createdAt"`
+	AcceptedAt   string           `json:"acceptedAt"`
+	CompletedAt  string           `json:"completedAt"`
+	DeletedAt    string           `json:"deletedAt"`
+	Status       AssignmentStatus `json:"status"`
 }
 
 type BulkAssignment struct {
@@ -46,6 +60,13 @@ type AssignmentService interface {
 	// createdBy: The ID of the user who created the assignments.
 	// Returns any error encountered.
 	CreateAssignments(userIds []string, labIds []string, createdBy string) error
+
+	// UpdateAssignment updates a set of assignment.
+	// userId : The ID of the user.
+	// labId : The ID of the lab.
+	// status: The new status of the assignment.
+	// Returns any error encountered.
+	UpdateAssignment(userId string, labId string, status string) error
 
 	// DeleteAssignments deletes a set of assignments.
 	// assignmentIds: The IDs of the assignments to delete.

--- a/internal/entity/assignment.go
+++ b/internal/entity/assignment.go
@@ -71,7 +71,7 @@ type AssignmentService interface {
 	// DeleteAssignments deletes a set of assignments.
 	// assignmentIds: The IDs of the assignments to delete.
 	// Returns any error encountered.
-	DeleteAssignments(assignmentIds []string) error
+	DeleteAssignments(assignmentIds []string, userPrincipal string) error
 }
 
 type AssignmentRepository interface {

--- a/internal/entity/assignment.go
+++ b/internal/entity/assignment.go
@@ -19,7 +19,7 @@ type Assignment struct {
 	CreatedBy    string           `json:"createdBy"`
 	DeletedBy    string           `json:"deletedBy"`
 	CreatedAt    string           `json:"createdAt"`
-	AcceptedAt   string           `json:"acceptedAt"`
+	StartedAt    string           `json:"startedAt"`
 	CompletedAt  string           `json:"completedAt"`
 	DeletedAt    string           `json:"deletedAt"`
 	Status       AssignmentStatus `json:"status"`

--- a/internal/handler/assignment.go
+++ b/internal/handler/assignment.go
@@ -248,7 +248,7 @@ func (a *assignmentHandler) DeleteMyAssignments(c *gin.Context) {
 		}
 	}
 
-	if err := a.assignmentService.DeleteAssignments(assignments); err != nil {
+	if err := a.assignmentService.DeleteAssignments(assignments, userPrincipal); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -263,7 +263,15 @@ func (a *assignmentHandler) DeleteAssignments(c *gin.Context) {
 		return
 	}
 
-	if err := a.assignmentService.DeleteAssignments(assignments); err != nil {
+	// Get the auth token from the request header
+	authToken := c.GetHeader("Authorization")
+
+	// Remove Bearer from the authToken
+	authToken = strings.Split(authToken, "Bearer ")[1]
+	//Get the user principal from the auth token
+	userPrincipal, _ := auth.GetUserPrincipalFromToken(authToken)
+
+	if err := a.assignmentService.DeleteAssignments(assignments, userPrincipal); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/handler/assignment.go
+++ b/internal/handler/assignment.go
@@ -5,18 +5,22 @@ import (
 	"strings"
 
 	"actlabs-hub/internal/auth"
+	"actlabs-hub/internal/config"
 	"actlabs-hub/internal/entity"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/exp/slog"
 )
 
 type assignmentHandler struct {
 	assignmentService entity.AssignmentService
+	appConfig         *config.Config
 }
 
-func NewAssignmentHandler(r *gin.RouterGroup, service entity.AssignmentService) {
+func NewAssignmentHandler(r *gin.RouterGroup, service entity.AssignmentService, appConfig *config.Config) {
 	handler := &assignmentHandler{
 		assignmentService: service,
+		appConfig:         appConfig,
 	}
 
 	r.GET("/assignment/labs", handler.GetAllLabsRedacted)
@@ -24,6 +28,9 @@ func NewAssignmentHandler(r *gin.RouterGroup, service entity.AssignmentService) 
 	r.GET("/assignment/my", handler.GetMyAssignments)
 	r.POST("/assignment/my", handler.CreateMyAssignments)
 	r.DELETE("/assignment/my", handler.DeleteMyAssignments)
+
+	// requires super secret header.
+	r.PUT("/assignment/:userId/:labId/:status", handler.UpdateAssignment)
 }
 
 func NewAssignmentHandlerMentorRequired(r *gin.RouterGroup, service entity.AssignmentService) {
@@ -189,6 +196,33 @@ func (a *assignmentHandler) CreateAssignments(c *gin.Context) {
 	}
 
 	c.Status(http.StatusCreated)
+}
+
+func (a *assignmentHandler) UpdateAssignment(c *gin.Context) {
+	userId := c.Param("userId")
+	labId := c.Param("labId")
+	status := c.Param("status")
+
+	// get super secret from header
+	protectedLabSecret := c.Request.Header.Get("ProtectedLabSecret")
+	if protectedLabSecret != a.appConfig.ProtectedLabSecret {
+		slog.Error("invalid protected lab secret",
+			slog.String("userId", userId),
+			slog.String("labId", labId),
+			slog.String("status", status),
+			slog.String("protectedLabSecret", protectedLabSecret),
+		)
+
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Protected lab secret is invalid."})
+		return
+	}
+
+	if err := a.assignmentService.UpdateAssignment(userId, labId, status); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
 func (a *assignmentHandler) DeleteMyAssignments(c *gin.Context) {

--- a/internal/repository/server.go
+++ b/internal/repository/server.go
@@ -823,6 +823,18 @@ func (s *serverRepository) DeleteResourceGroup(ctx context.Context, server entit
 		return err
 	}
 
+	// remove storage account and key from redis
+	err = s.rdb.Del(context.Background(), server.UserAlias+"-storageAccount", server.UserAlias+"-storageAccountKey").Err()
+	if err != nil {
+		slog.Debug("failed to delete storage account and key from redis",
+			slog.String("userPrincipalName", server.UserPrincipalName),
+			slog.String("subscriptionId", server.SubscriptionId),
+			slog.String("resourceGroup", server.ResourceGroup),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/service/assignment.go
+++ b/internal/service/assignment.go
@@ -200,11 +200,11 @@ func (a *assignmentService) UpdateAssignment(userId string, labId string, status
 		return err
 	}
 
-	if status == "accepted" {
-		assignment.AcceptedAt = helper.GetTodaysDateTimeString()
-	} else if status == "completed" {
+	if status == "InProgress" {
+		assignment.StartedAt = helper.GetTodaysDateTimeString()
+	} else if status == "Completed" {
 		assignment.CompletedAt = helper.GetTodaysDateTimeString()
-	} else if status == "deleted" {
+	} else if status == "Deleted" {
 		assignment.DeletedAt = helper.GetTodaysDateTimeString()
 	} else {
 		slog.Error("invalid status",

--- a/internal/service/assignment.go
+++ b/internal/service/assignment.go
@@ -172,7 +172,7 @@ func (a *assignmentService) CreateAssignments(userIds []string, labIds []string,
 				LabId:        labId,
 				CreatedBy:    createdBy,
 				CreatedAt:    helper.GetTodaysDateTimeString(),
-				Status:       "assigned",
+				Status:       entity.AssignmentStatusCreated,
 			}
 
 			if err := a.assignmentRepository.UpsertAssignment(assignment); err != nil {


### PR DESCRIPTION
This pull request includes various changes to improve the functionality and readability of the codebase. The most important changes include adding a new method to the `assignmentService` struct, updating methods in the `assignmentHandler` struct, introducing a new type and constants for assignment statuses, and making improvements to the cleanup process in the `serverRepository` struct.

Main service changes:

* [`internal/service/assignment.go`](diffhunk://#diff-6e2f6e44ac93fefa0ad59b8e7a691c7f52db749fa9d744a9760c966b1120d9f6L191-R269): Added a new method `UpdateAssignment` to the `assignmentService` struct.
* [`internal/handler/assignment.go`](diffhunk://#diff-13836b91e30dcc78203d65a6750223f1d1503dd9920540c613420483eb111d07R201-R227): Added a new method `UpdateAssignment` and updated the `DeleteMyAssignments` and `DeleteAssignments` methods in the `assignmentHandler` struct. [[1]](diffhunk://#diff-13836b91e30dcc78203d65a6750223f1d1503dd9920540c613420483eb111d07R201-R227) [[2]](diffhunk://#diff-13836b91e30dcc78203d65a6750223f1d1503dd9920540c613420483eb111d07L217-R251) [[3]](diffhunk://#diff-13836b91e30dcc78203d65a6750223f1d1503dd9920540c613420483eb111d07L232-R274)

Type safety and readability improvements:

* [`internal/entity/assignment.go`](diffhunk://#diff-cf0a482769eb0a050b5f88d819699422872951f5845553003111d5ca19949229R3-R25): Introduced a new type `AssignmentStatus` and constants for different assignment statuses. Updated the `AssignmentService` interface to include a new method `UpdateAssignment`. [[1]](diffhunk://#diff-cf0a482769eb0a050b5f88d819699422872951f5845553003111d5ca19949229R3-R25) [[2]](diffhunk://#diff-cf0a482769eb0a050b5f88d819699422872951f5845553003111d5ca19949229R64-R74)

Other important changes:

* [`cmd/actlabs-hub/main.go`](diffhunk://#diff-7bf50f0d432033660a66d89198850eb7fa9cd97e913af61afb583e28bf57829bL115-R115): Updated the `main` function to pass `appConfig` to the `assignmentHandler` struct instead of `assignmentService`.
* [`internal/repository/server.go`](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dR826-R837): Updated the `DeleteResourceGroup` method in the `serverRepository` struct to remove the storage account and key from Redis during cleanup.