### PR TITLE
Challenge v2

### DIFF
--- a/cmd/actlabs-hub/main.go
+++ b/cmd/actlabs-hub/main.go
@@ -113,7 +113,7 @@ func main() {
 	handler.NewHealthzHandler(authRouter.Group("/"))
 	handler.NewServerHandler(authRouter.Group("/"), serverService)
 	handler.NewAssignmentHandler(authRouter.Group("/"), assignmentService, appConfig)
-	handler.NewChallengeHandler(authRouter.Group("/"), challengeService)
+	handler.NewChallengeHandler(authRouter.Group("/"), challengeService, appConfig)
 	handler.NewAuthHandler(authRouter.Group("/"), authService)
 
 	armAuthRouter := router.Group("/")

--- a/internal/entity/challenge.go
+++ b/internal/entity/challenge.go
@@ -4,7 +4,6 @@ type ChallengeStatus = string
 
 const (
 	ChallengeStatusCreated    ChallengeStatus = "Created"
-	ChallengeStatusAccepted   ChallengeStatus = "Accepted"
 	ChallengeStatusCompleted  ChallengeStatus = "Completed"
 	ChallengeStatusCancelled  ChallengeStatus = "Cancelled"
 	ChallengeStatusInProgress ChallengeStatus = "InProgress"

--- a/internal/entity/challenge.go
+++ b/internal/entity/challenge.go
@@ -1,5 +1,16 @@
 package entity
 
+type ChallengeStatus = string
+
+const (
+	ChallengeStatusCreated    ChallengeStatus = "Created"
+	ChallengeStatusAccepted   ChallengeStatus = "Accepted"
+	ChallengeStatusCompleted  ChallengeStatus = "Completed"
+	ChallengeStatusCancelled  ChallengeStatus = "Cancelled"
+	ChallengeStatusInProgress ChallengeStatus = "InProgress"
+	ChallengeStatusDeleted    ChallengeStatus = "Deleted"
+)
+
 type Challenge struct {
 	PartitionKey string `json:"PartitionKey"`
 	RowKey       string `json:"RowKey"`
@@ -45,6 +56,13 @@ type ChallengeService interface {
 	// UpsertChallenges upsert challenge.
 	// Returns any error encountered.
 	UpsertChallenges(Challenges []Challenge) error
+
+	// UpdateChallenge updates a challenge.
+	// userId : The ID of the user.
+	// labId : The ID of the lab.
+	// status: The new status of the challenge.
+	// Returns any error encountered.
+	UpdateChallenge(userId string, labId string, status string) error
 
 	// CreateChallenges creates new challenges for a set of users and labs.
 	// userIds: The IDs of the users.

--- a/internal/entity/challenge.go
+++ b/internal/entity/challenge.go
@@ -3,24 +3,23 @@ package entity
 type ChallengeStatus = string
 
 const (
-	ChallengeStatusCreated    ChallengeStatus = "Created"
-	ChallengeStatusCompleted  ChallengeStatus = "Completed"
-	ChallengeStatusCancelled  ChallengeStatus = "Cancelled"
-	ChallengeStatusInProgress ChallengeStatus = "InProgress"
-	ChallengeStatusDeleted    ChallengeStatus = "Deleted"
+	ChallengeStatusCreated   ChallengeStatus = "created"
+	ChallengeStatusCompleted ChallengeStatus = "completed"
+	ChallengeStatusFailed    ChallengeStatus = "failed"
+	ChallengeStatusAccepted  ChallengeStatus = "accepted"
 )
 
 type Challenge struct {
-	PartitionKey string `json:"PartitionKey"`
-	RowKey       string `json:"RowKey"`
-	ChallengeId  string `json:"challengeId"`
-	UserId       string `json:"userId"`
-	LabId        string `json:"labId"`
-	CreatedBy    string `json:"createdBy"`
-	CreatedOn    string `json:"createdOn"`
-	AcceptedOn   string `json:"acceptedOn"`
-	CompletedOn  string `json:"completedOn"`
-	Status       string `json:"status"`
+	PartitionKey string          `json:"PartitionKey"`
+	RowKey       string          `json:"RowKey"`
+	ChallengeId  string          `json:"challengeId"`
+	UserId       string          `json:"userId"`
+	LabId        string          `json:"labId"`
+	CreatedBy    string          `json:"createdBy"`
+	CreatedOn    string          `json:"createdOn"`
+	AcceptedOn   string          `json:"acceptedOn"`
+	CompletedOn  string          `json:"completedOn"`
+	Status       ChallengeStatus `json:"status"`
 }
 
 type BulkChallenge struct {

--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -98,6 +98,7 @@ type LabType struct {
 	Owners           []string        `json:"owners"`
 	Editors          []string        `json:"editors"`
 	Viewers          []string        `json:"viewers"`
+	IsPublished      bool            `json:"isPublished"`
 	VersionId        string          `json:"versionId"`
 	IsCurrentVersion bool            `json:"isCurrentVersion"`
 }

--- a/internal/handler/challenge.go
+++ b/internal/handler/challenge.go
@@ -124,7 +124,7 @@ func (ch *challengeHandler) UpdateChallenge(c *gin.Context) {
 
 	// get super secret from header
 	protectedLabSecret := c.Request.Header.Get("ProtectedLabSecret")
-	if protectedLabSecret != a.appConfig.ProtectedLabSecret {
+	if protectedLabSecret != ch.appConfig.ProtectedLabSecret {
 		slog.Error("invalid protected lab secret",
 			slog.String("userId", userId),
 			slog.String("labId", labId),

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -114,6 +114,7 @@ func (s *AutoDestroyService) VerifyServerIdle(server entity.Server) bool {
 	isIdle, err := s.serverRepository.EnsureServerIdle(server)
 	if err != nil {
 		slog.Error("not able to verify server idle",
+			slog.String("userPrincipalName", server.UserPrincipalName),
 			slog.String("error", err.Error()),
 		)
 		return false

--- a/internal/service/autodestroy.go
+++ b/internal/service/autodestroy.go
@@ -88,6 +88,7 @@ func (s *AutoDestroyService) DestroyIdleServers(ctx context.Context) error {
 			server.Status != entity.ServerStatusAutoDestroyed &&
 			server.Status != entity.ServerStatusDestroyed &&
 			server.Status != entity.ServerStatusUnregistered &&
+			server.Status != entity.ServerStatusRegistered &&
 			time.Since(lastActivityTime) > time.Duration(server.InactivityDurationInSeconds)*time.Second &&
 			s.VerifyServerIdle(server) {
 

--- a/internal/service/challenge.go
+++ b/internal/service/challenge.go
@@ -206,6 +206,56 @@ func (c *challengeService) CreateChallenges(userIds []string, labIds []string, c
 	return nil
 }
 
+func (c *challengeService) UpdateChallenge(userId string, labId string, status string) error {
+	slog.Info("updating challenge",
+		slog.String("userId", userId),
+		slog.String("labId", labId),
+		slog.String("status", status),
+	)
+
+	challenges, err := c.challengeRepository.GetChallengesByUserId(userId)
+	if err != nil {
+		slog.Error("not able to get challenge",
+			slog.String("userId", userId),
+			slog.String("labId", labId),
+			slog.String("error", err.Error()),
+		)
+
+		return fmt.Errorf("not able to get challenges for user id %s", userId)
+	}
+
+	var challenge entity.Challenge
+	for _, c := range challenges {
+		if c.LabId == labId {
+			challenge = c
+			break
+		}
+	}
+
+	if challenge.ChallengeId == "" {
+		slog.Error("challenge not found",
+			slog.String("userId", userId),
+			slog.String("labId", labId),
+		)
+
+		return fmt.Errorf("challenge not found for user id %s and lab id %s", userId, labId)
+	}
+
+	challenge.Status = status
+
+	if err := c.challengeRepository.UpsertChallenge(challenge); err != nil {
+		slog.Error("not able to update challenge",
+			slog.String("userId", userId),
+			slog.String("labId", labId),
+			slog.String("error", err.Error()),
+		)
+
+		return fmt.Errorf("not able to update challenge for user id %s and lab id %s", userId, labId)
+	}
+
+	return nil
+}
+
 func (c *challengeService) DeleteChallenges(challengeIds []string) error {
 	slog.Info("deleting challenges",
 		slog.String("challengeIds", strings.Join(challengeIds, ",")),


### PR DESCRIPTION
This pull request primarily introduces enhancements to the challenge handling in the `actlabs-hub` application. The changes include the addition of a new `ChallengeStatus` type and related constants, modifications to the `Challenge` struct and `ChallengeService` interface, and the introduction of new methods in the `challengeHandler` and `challengeService` classes. Additionally, minor changes were made to the `AutoDestroyService` class and the `LabType` struct. 

Here are the most important changes:

#### Challenge Handling Enhancements:

* [`internal/entity/challenge.go`](diffhunk://#diff-44753e53e9d20a699912b3030403dc393e23491a1ecf4a24fb9ad2543de9dfb6R3-R11): Introduced a new type `ChallengeStatus` and related constants to represent the various states a challenge can be in. Modified the `Challenge` struct to use the new `ChallengeStatus` type for the `Status` field. Added a new method `UpdateChallenge` to the `ChallengeService` interface to allow updating a challenge's status. [[1]](diffhunk://#diff-44753e53e9d20a699912b3030403dc393e23491a1ecf4a24fb9ad2543de9dfb6R3-R11) [[2]](diffhunk://#diff-44753e53e9d20a699912b3030403dc393e23491a1ecf4a24fb9ad2543de9dfb6L13-R22) [[3]](diffhunk://#diff-44753e53e9d20a699912b3030403dc393e23491a1ecf4a24fb9ad2543de9dfb6R58-R64)

* [`cmd/actlabs-hub/main.go`](diffhunk://#diff-7bf50f0d432033660a66d89198850eb7fa9cd97e913af61afb583e28bf57829bL116-R116): Modified the `NewChallengeHandler` method call to include `appConfig` as a new parameter.

* [`internal/handler/challenge.go`](diffhunk://#diff-4f901414ffa7ccdfa50a28edda409d06daff8997657227a61a3dd806c57b2c5bR5-R22): Imported the `config` package and updated the `NewChallengeHandler` method to accept and use `appConfig`. Added a new method `UpdateChallenge` to update a challenge's status, which requires a super-secret header for authorization. [[1]](diffhunk://#diff-4f901414ffa7ccdfa50a28edda409d06daff8997657227a61a3dd806c57b2c5bR5-R22) [[2]](diffhunk://#diff-4f901414ffa7ccdfa50a28edda409d06daff8997657227a61a3dd806c57b2c5bR32-R34) [[3]](diffhunk://#diff-4f901414ffa7ccdfa50a28edda409d06daff8997657227a61a3dd806c57b2c5bR120-R146)

* [`internal/service/challenge.go`](diffhunk://#diff-8af4fd9dc0f6a196dc979b1ae26c043ed9517ce96006f5f5b6a59292b5b76dcfR145-R161): Updated the `UpsertChallenges` method to handle `ChallengeStatusAccepted` and `ChallengeStatusCreated` statuses, and return an error for invalid statuses. Added a new method `UpdateChallenge` to update a challenge's status, with error handling for invalid statuses and non-existent challenges. [[1]](diffhunk://#diff-8af4fd9dc0f6a196dc979b1ae26c043ed9517ce96006f5f5b6a59292b5b76dcfR145-R161) [[2]](diffhunk://#diff-8af4fd9dc0f6a196dc979b1ae26c043ed9517ce96006f5f5b6a59292b5b76dcfR232-R294)

#### Other Changes:

* [`internal/entity/lab.go`](diffhunk://#diff-d5633b476a884b495935badf2ed1541228f738e3083bd4538801bda63c0aa0d4R101): Added a new field `IsPublished` to the `LabType` struct.

* [`internal/service/autodestroy.go`](diffhunk://#diff-be81ece7a4536992685a923816817ffa4412c24defcc47c292cc93e8dbbbe9caR91): Modified the `DestroyIdleServers` method to also exclude servers with `ServerStatusRegistered` status. Added logging of `userPrincipalName` in the `VerifyServerIdle` method. [[1]](diffhunk://#diff-be81ece7a4536992685a923816817ffa4412c24defcc47c292cc93e8dbbbe9caR91) [[2]](diffhunk://#diff-be81ece7a4536992685a923816817ffa4412c24defcc47c292cc93e8dbbbe9caR118)

* [`internal/service/challenge.go`](diffhunk://#diff-8af4fd9dc0f6a196dc979b1ae26c043ed9517ce96006f5f5b6a59292b5b76dcfR39-R44): Updated the `GetAllLabsRedacted` method to only show published labs.