### PR TITLE
Lab docs and Support Access Changes

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -58,7 +58,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsServersTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubManagedServersTableName,
 	)
@@ -67,7 +67,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsReadinessTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubReadinessAssignmentsTableName,
 	)
@@ -76,7 +76,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsChallengesTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubChallengesTableName,
 	)
@@ -85,7 +85,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsProfilesTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubProfilesTableName,
 	)
@@ -94,7 +94,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsDeploymentsTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubDeploymentsTableName,
 	)
@@ -103,7 +103,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsEventsTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubEventsTableName,
 	)
@@ -112,7 +112,7 @@ func NewAuth(appConfig *config.Config) (*Auth, error) {
 	}
 
 	actlabsDeploymentOperationsTableClient, err := GetTableClient(
-		accountKey,
+		cred,
 		appConfig.ActlabsHubStorageAccount,
 		appConfig.ActlabsHubDeploymentOperationsTableName,
 	)
@@ -152,13 +152,8 @@ func GetStorageAccountKey(subscriptionId string, cred azcore.TokenCredential, re
 	return *resp.Keys[0].Value, nil
 }
 
-func GetTableClient(accountKey string, storageAccountName string, tableName string) (*aztables.Client, error) {
-	sharedKeyCred, err := aztables.NewSharedKeyCredential(storageAccountName, accountKey)
-	if err != nil {
-		return &aztables.Client{}, fmt.Errorf("error creating shared key credential %w", err)
-	}
-
+func GetTableClient(cred azcore.TokenCredential, storageAccountName string, tableName string) (*aztables.Client, error) {
 	tableUrl := "https://" + storageAccountName + ".table.core.windows.net/" + tableName
 
-	return aztables.NewClientWithSharedKey(tableUrl, sharedKeyCred, nil)
+	return aztables.NewClient(tableUrl, cred, nil)
 }

--- a/internal/entity/assignment.go
+++ b/internal/entity/assignment.go
@@ -33,7 +33,7 @@ type BulkAssignment struct {
 type AssignmentService interface {
 	// GetAllLabsRedacted retrieves all labs assigned to a user, with sensitive information redacted.
 	// Returns an array of LabType (with redacted information) and any error encountered.
-	GetAllLabsRedacted() ([]LabType, error)
+	GetAllLabsRedacted(userId string) ([]LabType, error)
 
 	// GetMyAssignedLabs retrieves all labs assigned to a specific user.
 	// userId: The ID of the user.

--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -132,10 +132,10 @@ type LabService interface {
 	// Protected Labs
 	// Role: mentor
 	// Types: readinesslab, mockcase
-	GetProtectedLabs(typeOfLab string) ([]LabType, error)
-	GetProtectedLab(typeOfLab string, labId string) (LabType, error)
+	GetProtectedLabs(typeOfLab string, userId string, requestIsWithSecret bool) ([]LabType, error)
+	GetProtectedLab(typeOfLab string, labId string, userId string, requestIsWithSecret bool) (LabType, error)
 	GetProtectedLabVersions(typeOfLab string, labId string) ([]LabType, error)
-	UpsertProtectedLab(LabType) (LabType, error)
+	UpsertProtectedLab(lab LabType, userId string) (LabType, error)
 	DeleteProtectedLab(typeOfLab string, labId string) error
 
 	// Shared functions
@@ -148,6 +148,7 @@ type LabService interface {
 	UpsertSupportingDocument(ctx context.Context, supportingDocument multipart.File) (string, error)
 	DeleteSupportingDocument(ctx context.Context, supportingDocumentId string) error
 	GetSupportingDocument(ctx context.Context, supportingDocumentId string) (io.ReadCloser, error)
+	DoesSupportingDocumentExist(ctx context.Context, supportingDocumentId string) bool
 }
 
 type LabRepository interface {
@@ -167,4 +168,5 @@ type LabRepository interface {
 	UpsertSupportingDocument(ctx context.Context, supportingDocument multipart.File) (string, error)
 	DeleteSupportingDocument(ctx context.Context, supportingDocumentId string) error
 	GetSupportingDocument(ctx context.Context, supportingDocumentId string) (io.ReadCloser, error)
+	DoesSupportingDocumentExist(ctx context.Context, supportingDocumentId string) bool
 }

--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -1,6 +1,10 @@
 package entity
 
-import "context"
+import (
+	"context"
+	"io"
+	"mime/multipart"
+)
 
 type TfvarResourceGroupType struct {
 	Location string `json:"location"`
@@ -83,25 +87,27 @@ var (
 )
 
 type LabType struct {
-	Id               string          `json:"id"`
-	Name             string          `json:"name"`
-	Description      string          `json:"description"`
-	Tags             []string        `json:"tags"`
-	Template         TfvarConfigType `json:"template"`
-	ExtendScript     string          `json:"extendScript"`
-	Message          string          `json:"message"`
-	Category         string          `json:"category"`
-	Type             string          `json:"type"`
-	CreatedBy        string          `json:"createdBy"`
-	CreatedOn        string          `json:"createdOn"`
-	UpdatedBy        string          `json:"updatedBy"`
-	UpdatedOn        string          `json:"updatedOn"`
-	Owners           []string        `json:"owners"`
-	Editors          []string        `json:"editors"`
-	Viewers          []string        `json:"viewers"`
-	IsPublished      bool            `json:"isPublished"`
-	VersionId        string          `json:"versionId"`
-	IsCurrentVersion bool            `json:"isCurrentVersion"`
+	Id                       string          `json:"id"`
+	Name                     string          `json:"name"`
+	Description              string          `json:"description"`
+	Tags                     []string        `json:"tags"`
+	Template                 TfvarConfigType `json:"template"`
+	ExtendScript             string          `json:"extendScript"`
+	Message                  string          `json:"message"`
+	Category                 string          `json:"category"`
+	Type                     string          `json:"type"`
+	CreatedBy                string          `json:"createdBy"`
+	CreatedOn                string          `json:"createdOn"`
+	UpdatedBy                string          `json:"updatedBy"`
+	UpdatedOn                string          `json:"updatedOn"`
+	Owners                   []string        `json:"owners"`
+	Editors                  []string        `json:"editors"`
+	Viewers                  []string        `json:"viewers"`
+	RbacEnforcedProtectedLab bool            `json:"rbacEnforcedProtectedLab"`
+	IsPublished              bool            `json:"isPublished"`
+	VersionId                string          `json:"versionId"`
+	IsCurrentVersion         bool            `json:"isCurrentVersion"`
+	SupportingDocumentId     string          `json:"supportingDocumentId"`
 }
 
 type LabService interface {
@@ -137,6 +143,11 @@ type LabService interface {
 	GetLabVersions(typeOfLab string, labId string) ([]LabType, error)
 	UpsertLab(LabType) (LabType, error)
 	DeleteLab(typeOfLab string, labId string) error
+
+	// Supporting Documents
+	UpsertSupportingDocument(ctx context.Context, supportingDocument multipart.File) (string, error)
+	DeleteSupportingDocument(ctx context.Context, supportingDocumentId string) error
+	GetSupportingDocument(ctx context.Context, supportingDocumentId string) (io.ReadCloser, error)
 }
 
 type LabRepository interface {
@@ -151,4 +162,9 @@ type LabRepository interface {
 
 	UpsertLab(ctx context.Context, labId string, lab string, typeOfLab string) error
 	DeleteLab(ctx context.Context, typeOfLab string, labId string) error
+
+	// Supporting Documents
+	UpsertSupportingDocument(ctx context.Context, supportingDocument multipart.File) (string, error)
+	DeleteSupportingDocument(ctx context.Context, supportingDocumentId string) error
+	GetSupportingDocument(ctx context.Context, supportingDocumentId string) (io.ReadCloser, error)
 }

--- a/internal/handler/assignment.go
+++ b/internal/handler/assignment.go
@@ -56,7 +56,14 @@ func (a *assignmentHandler) GetAllAssignments(c *gin.Context) {
 }
 
 func (a *assignmentHandler) GetAllLabsRedacted(c *gin.Context) {
-	labs, err := a.assignmentService.GetAllLabsRedacted()
+
+	// Get the auth token from the request header
+	authToken := c.GetHeader("Authorization")
+	// Remove Bearer from the authToken
+	authToken = strings.Split(authToken, "Bearer ")[1]
+	userId, _ := auth.GetUserPrincipalFromToken(authToken)
+
+	labs, err := a.assignmentService.GetAllLabsRedacted(userId)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/repository/lab.go
+++ b/internal/repository/lab.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 
 	"actlabs-hub/internal/auth"
 	"actlabs-hub/internal/config"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/exp/slog"
 )
@@ -320,6 +322,56 @@ func (l *labRepository) DeleteLab(ctx context.Context, typeOfLab string, labId s
 	l.rdb.Del(ctx, "blobs-"+typeOfLab)
 	l.rdb.Del(ctx, redisKey("labWithVersions", typeOfLab, appendDotJson(labId)))
 	l.rdb.Del(ctx, redisKey("lab", typeOfLab, appendDotJson(labId)))
+
+	return nil
+}
+
+func (l *labRepository) UpsertSupportingDocument(ctx context.Context, supportingDocument multipart.File) (string, error) {
+	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", l.appConfig.ActlabsHubStorageAccount)
+	client, err := azblob.NewClient(serviceURL, l.auth.Cred, nil)
+	if err != nil {
+		return "", err
+	}
+
+	containerName := "repro-project-supporting-documents"
+	blobName := uuid.New().String()
+
+	_, err = client.UploadStream(ctx, containerName, blobName, supportingDocument, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return blobName, nil
+}
+
+func (l *labRepository) GetSupportingDocument(ctx context.Context, supportingDocumentId string) (io.ReadCloser, error) {
+	containerUrl := fmt.Sprintf("https://%s.blob.core.windows.net/%s", l.appConfig.ActlabsHubStorageAccount, "repro-project-supporting-documents")
+	containerClient, err := container.NewClient(containerUrl, l.auth.Cred, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	blobClient := containerClient.NewBlobClient(supportingDocumentId)
+
+	downloadResponse, err := blobClient.DownloadStream(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return downloadResponse.Body, nil
+}
+
+func (l *labRepository) DeleteSupportingDocument(ctx context.Context, supportingDocumentId string) error {
+	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", l.appConfig.ActlabsHubStorageAccount)
+	client, err := azblob.NewClient(serviceURL, l.auth.Cred, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.DeleteBlob(ctx, "repro-project-supporting-documents", supportingDocumentId, nil)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/repository/lab.go
+++ b/internal/repository/lab.go
@@ -376,6 +376,23 @@ func (l *labRepository) DeleteSupportingDocument(ctx context.Context, supporting
 	return nil
 }
 
+func (l *labRepository) DoesSupportingDocumentExist(ctx context.Context, supportingDocumentId string) bool {
+	containerUrl := fmt.Sprintf("https://%s.blob.core.windows.net/%s", l.appConfig.ActlabsHubStorageAccount, "repro-project-supporting-documents")
+	containerClient, err := container.NewClient(containerUrl, l.auth.Cred, nil)
+	if err != nil {
+		return false
+	}
+
+	blobClient := containerClient.NewBlobClient(supportingDocumentId)
+
+	_, err = blobClient.GetProperties(ctx, nil)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
 func appendDotJson(labId string) string {
 	if labId[len(labId)-5:] == ".json" {
 		return labId

--- a/internal/repository/server.go
+++ b/internal/repository/server.go
@@ -796,6 +796,9 @@ func (s *serverRepository) DestroyAzureContainerGroup(server entity.Server) erro
 	ctx := context.Background()
 
 	cred := s.auth.Cred
+	if server.Version == "V3" {
+		cred = s.auth.FdpoCredential
+	}
 
 	clientFactory, err := armcontainerinstance.NewContainerGroupsClient(server.SubscriptionId, cred, nil)
 	if err != nil {
@@ -890,8 +893,13 @@ func (s *serverRepository) IsUserAuthorized(server entity.Server) (bool, error) 
 
 	// Updates for FDPO Environments.
 	// The userPrincipalId is different for FDPO environments. This is the object ID in new tenant.
+	// The FDPO Credentials are different from the normal credentials.
 	if server.Version == "V3" {
 		userPrincipalId = server.FdpoUserPrincipalId
+		clientFactory, err = armauthorization.NewClientFactory(server.SubscriptionId, s.auth.FdpoCredential, nil)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	filter := "assignedTo('" + userPrincipalId + "')"
@@ -1085,6 +1093,9 @@ func (s *serverRepository) GetResourceGroupRegion(ctx context.Context, server en
 func (s *serverRepository) DeleteResourceGroup(ctx context.Context, server entity.Server) error {
 
 	cred := s.auth.Cred
+	if server.Version == "V3" {
+		cred = s.auth.FdpoCredential
+	}
 
 	clientFactory, err := armresources.NewClientFactory(server.SubscriptionId, cred, nil)
 	if err != nil {
@@ -1124,6 +1135,9 @@ func (s *serverRepository) DeleteResourceGroup(ctx context.Context, server entit
 func (s *serverRepository) DeleteStorageAccount(ctx context.Context, server entity.Server) error {
 
 	cred := s.auth.Cred
+	if server.Version == "V3" {
+		cred = s.auth.FdpoCredential
+	}
 
 	clientFactory, err := armstorage.NewClientFactory(server.SubscriptionId, cred, nil)
 	if err != nil {

--- a/internal/service/assignment.go
+++ b/internal/service/assignment.go
@@ -71,11 +71,11 @@ func (a *assignmentService) GetAssignmentsByUserId(userId string) ([]entity.Assi
 	return assignments, nil
 }
 
-func (a *assignmentService) GetAllLabsRedacted() ([]entity.LabType, error) {
+func (a *assignmentService) GetAllLabsRedacted(userId string) ([]entity.LabType, error) {
 	slog.Info("getting all labs redacted")
 	readinessLabRedacted := []entity.LabType{}
 
-	labs, err := a.labService.GetProtectedLabs("readinesslab")
+	labs, err := a.labService.GetProtectedLabs("readinesslab", userId, false)
 	if err != nil {
 		slog.Error("not able to get readiness labs",
 			slog.String("error", err.Error()),
@@ -110,7 +110,7 @@ func (a *assignmentService) GetAssignedLabsRedactedByUserId(userId string) ([]en
 		return assignedLabs, err
 	}
 
-	labs, err := a.labService.GetProtectedLabs("readinesslab")
+	labs, err := a.labService.GetProtectedLabs("readinesslab", userId, false)
 	if err != nil {
 		slog.Error("not able to get readiness labs",
 			slog.String("userId", userId),

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -247,6 +247,24 @@ func (l *labService) DeleteProtectedLab(typeOfLab string, labId string) error {
 }
 
 func (l *labService) DeleteLab(typeOfLab string, labId string) error {
+	// Delete supporting document if any.
+	lab, err := l.labRepository.GetLab(context.TODO(), typeOfLab, labId)
+	if err != nil {
+		slog.Error("not able to get lab",
+			slog.String("labId", labId),
+		)
+		return err
+	}
+
+	if lab.SupportingDocumentId != "" {
+		if err := l.DeleteSupportingDocument(context.TODO(), lab.SupportingDocumentId); err != nil {
+			slog.Error("not able to delete supporting document",
+				slog.String("error", err.Error()),
+			)
+			return err
+		}
+	}
+
 	if err := l.labRepository.DeleteLab(context.TODO(), typeOfLab, labId); err != nil {
 		slog.Error("not able to delete lab",
 			slog.String("error", err.Error()),

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"strings"
 
 	"actlabs-hub/internal/entity"
@@ -287,6 +289,42 @@ func (l *labService) GetLabVersions(typeOfLab string, labId string) ([]entity.La
 	}
 
 	return labs, nil
+}
+
+// Supporting Documents
+func (l *labService) UpsertSupportingDocument(ctx context.Context, supportingDocument multipart.File) (string, error) {
+	supportingDocumentId, err := l.labRepository.UpsertSupportingDocument(ctx, supportingDocument)
+	if err != nil {
+		slog.Error("not able to save supporting document",
+			slog.String("error", err.Error()),
+		)
+		return "", err
+	}
+
+	return supportingDocumentId, nil
+}
+
+func (l *labService) DeleteSupportingDocument(ctx context.Context, supportingDocumentId string) error {
+	if err := l.labRepository.DeleteSupportingDocument(ctx, supportingDocumentId); err != nil {
+		slog.Error("not able to delete supporting document",
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+
+	return nil
+}
+
+func (l *labService) GetSupportingDocument(ctx context.Context, supportingDocumentId string) (io.ReadCloser, error) {
+	supportingDocument, err := l.labRepository.GetSupportingDocument(ctx, supportingDocumentId)
+	if err != nil {
+		slog.Error("not able to get supporting document",
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+
+	return supportingDocument, nil
 }
 
 // Helper functions.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -205,6 +205,22 @@ function create_storage_account() {
     fi
   fi
 
+  # Enable shared key access to the storage account
+  log "checking if shared key access is enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+  SHARED_KEY_ACCESS=$(az storage account show --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --query "allowSharedKeyAccess" --output tsv)
+  if [[ ${SHARED_KEY_ACCESS} == "false" ]]; then
+    log "enabling shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
+    az storage account update --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --allow-shared-key-access true
+    if [ $? -ne 0 ]; then
+      err "failed to enable shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
+      exit 1
+    else
+      log "shared key access enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+    fi
+  else
+    log "shared key access is already enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+  fi
+
   # get storage account key
   STORAGE_ACCOUNT_KEY=$(az storage account keys list --resource-group "${RESOURCE_GROUP}" --account-name "${STORAGE_ACCOUNT_NAME}" --query "[0].value" -o tsv)
 
@@ -243,24 +259,6 @@ function create_storage_account() {
   fi
 
   return 0
-}
-
-function enable_shared_key_access() {
-  # Enable shared key access to storage account if not already enabled
-  log "checking if shared key access is enabled for storage account ${STORAGE_ACCOUNT_NAME}"
-  SHARED_KEY_ACCESS=$(az storage account show --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --query "allowSharedKeyAccess" --output tsv)
-  if [[ ${SHARED_KEY_ACCESS} == "false" ]]; then
-    log "enabling shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
-    az storage account update --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --allow-shared-key-access true
-    if [ $? -ne 0 ]; then
-      err "failed to enable shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
-      exit 1
-    else
-      log "shared key access enabled for storage account ${STORAGE_ACCOUNT_NAME}"
-    fi
-  else
-    log "shared key access is already enabled for storage account ${STORAGE_ACCOUNT_NAME}"
-  fi
 }
 
 # Function to check if managed identity is 'Contributor' on the subscription
@@ -419,7 +417,6 @@ if [[ "${is_owner}" == false ]]; then
 fi
 create_resource_group
 create_storage_account
-enable_shared_key_access
 if [[ "${is_owner}" == true ]]; then
   assign_contributor_role
   assign_user_access_administrator_role

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -210,12 +210,14 @@ function create_storage_account() {
   SHARED_KEY_ACCESS=$(az storage account show --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --query "allowSharedKeyAccess" --output tsv)
   if [[ ${SHARED_KEY_ACCESS} == "false" ]]; then
     log "enabling shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
-    az storage account update --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --allow-shared-key-access true
+    az storage account update --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --allow-shared-key-access true >/dev/null 2>&1
     if [ $? -ne 0 ]; then
       err "failed to enable shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
       exit 1
     else
       log "shared key access enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+      log "waiting for 30 seconds for the changes to take effect"
+      sleep_with_progress 30
     fi
   else
     log "shared key access is already enabled for storage account ${STORAGE_ACCOUNT_NAME}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -245,6 +245,24 @@ function create_storage_account() {
   return 0
 }
 
+function enable_shared_key_access() {
+  # Enable shared key access to storage account if not already enabled
+  log "checking if shared key access is enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+  SHARED_KEY_ACCESS=$(az storage account show --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --query "allowSharedKeyAccess" --output tsv)
+  if [[ ${SHARED_KEY_ACCESS} == "false" ]]; then
+    log "enabling shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
+    az storage account update --name ${STORAGE_ACCOUNT_NAME} -g "${RESOURCE_GROUP}" --allow-shared-key-access true
+    if [ $? -ne 0 ]; then
+      err "failed to enable shared key access for storage account ${STORAGE_ACCOUNT_NAME}"
+      exit 1
+    else
+      log "shared key access enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+    fi
+  else
+    log "shared key access is already enabled for storage account ${STORAGE_ACCOUNT_NAME}"
+  fi
+}
+
 # Function to check if managed identity is 'Contributor' on the subscription
 # If not, assign the managed identity the 'Contributor' role on the subscription
 function assign_contributor_role() {
@@ -401,6 +419,7 @@ if [[ "${is_owner}" == false ]]; then
 fi
 create_resource_group
 create_storage_account
+enable_shared_key_access
 if [[ "${is_owner}" == true ]]; then
   assign_contributor_role
   assign_user_access_administrator_role


### PR DESCRIPTION
This pull request includes various changes to the `internal/auth`, `internal/entity`, `internal/handler`, and `internal/repository` packages. The most important changes include updating authentication methods, enhancing lab entity management, and adding support for handling supporting documents.

### Authentication Updates:
* [`internal/auth/auth.go`](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL61-R61): Modified `GetTableClient` function to use `cred` instead of `accountKey` for creating table clients. [[1]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL61-R61) [[2]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL70-R70) [[3]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL79-R79) [[4]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL88-R88) [[5]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL97-R97) [[6]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL106-R106) [[7]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL115-R115) [[8]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL155-R158)

### Lab Entity Enhancements:
* [`internal/entity/lab.go`](diffhunk://#diff-d5633b476a884b495935badf2ed1541228f738e3083bd4538801bda63c0aa0d4R106-R110): Added `RbacEnforcedProtectedLab` and `SupportingDocumentId` fields to `LabType`.
* [`internal/entity/lab.go`](diffhunk://#diff-d5633b476a884b495935badf2ed1541228f738e3083bd4538801bda63c0aa0d4L129-R151): Updated `LabService` and `LabRepository` interfaces to include methods for handling supporting documents. [[1]](diffhunk://#diff-d5633b476a884b495935badf2ed1541228f738e3083bd4538801bda63c0aa0d4L129-R151) [[2]](diffhunk://#diff-d5633b476a884b495935badf2ed1541228f738e3083bd4538801bda63c0aa0d4R166-R171)

### Supporting Document Management:
* [`internal/handler/lab.go`](diffhunk://#diff-57c2e9592ae1532b670cec67c4fd28b98c526ec7da2d3e726a4096af5aeea92aR69-R108): Added new endpoints and handler methods for uploading, retrieving, and deleting supporting documents. [[1]](diffhunk://#diff-57c2e9592ae1532b670cec67c4fd28b98c526ec7da2d3e726a4096af5aeea92aR69-R108) [[2]](diffhunk://#diff-57c2e9592ae1532b670cec67c4fd28b98c526ec7da2d3e726a4096af5aeea92aR353-R413)
* [`internal/repository/lab.go`](diffhunk://#diff-b334c06f061418015e9b69175e602a44f62ffe4b486bf7ab29116e6fdd9288b9R9-R17): Imported necessary packages for handling multipart file uploads and UUID generation.

### Other Changes:
* [`internal/entity/assignment.go`](diffhunk://#diff-cf0a482769eb0a050b5f88d819699422872951f5845553003111d5ca19949229L36-R36): Modified `GetAllLabsRedacted` method signature to include `userId` parameter.
* [`internal/handler/assignment.go`](diffhunk://#diff-13836b91e30dcc78203d65a6750223f1d1503dd9920540c613420483eb111d07L59-R66): Updated `GetAllLabsRedacted` handler to extract `userId` from the auth token.