### PR TITLE
Server cleanup

### DIFF
--- a/cmd/actlabs-hub/main.go
+++ b/cmd/actlabs-hub/main.go
@@ -110,7 +110,7 @@ func main() {
 	router.SetTrustedProxies(nil)
 
 	config := cors.DefaultConfig()
-	config.AllowOrigins = []string{"http://localhost:3000", "http://localhost:5173", "https://ashisverma.z13.web.core.windows.net", "https://actlabs.z13.web.core.windows.net", "https://actlabsbeta.z13.web.core.windows.net", "https://actlabs.azureedge.net", "https://actlabs-app.azureedge.net", "https://*.azurewebsites.net"}
+	config.AllowOrigins = []string{"http://localhost:3000", "http://localhost:5173", "https://ashisverma.z13.web.core.windows.net", "https://actlabs.z13.web.core.windows.net", "https://actlabsbeta.z13.web.core.windows.net", "https://actlabs.azureedge.net", "https://actlabs-app.azureedge.net", "https://*.azurewebsites.net", "https://*.msftactlabs.com"}
 	config.AllowMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
 	config.AllowHeaders = []string{"Authorization", "Content-Type"}
 

--- a/cmd/actlabs-hub/main.go
+++ b/cmd/actlabs-hub/main.go
@@ -110,7 +110,7 @@ func main() {
 	router.SetTrustedProxies(nil)
 
 	config := cors.DefaultConfig()
-	config.AllowOrigins = []string{"http://localhost:3000", "http://localhost:5173", "https://ashisverma.z13.web.core.windows.net", "https://actlabs.z13.web.core.windows.net", "https://actlabsbeta.z13.web.core.windows.net", "https://actlabs.azureedge.net", "https://actlabs-app.azureedge.net", "https://*.azurewebsites.net", "https://*.msftactlabs.com"}
+	config.AllowOrigins = []string{"http://localhost:3000", "http://localhost:5173", "https://ashisverma.z13.web.core.windows.net", "https://actlabs.z13.web.core.windows.net", "https://actlabsbeta.z13.web.core.windows.net", "https://actlabs.azureedge.net", "https://actlabs-app.azureedge.net", "https://*.azurewebsites.net", "https://app.msftactlabs.com"}
 	config.AllowMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
 	config.AllowHeaders = []string{"Authorization", "Content-Type"}
 


### PR DESCRIPTION
This pull request includes updates to the `cmd/actlabs-hub/main.go` and `internal/repository/server.go` files to enhance the handling of credentials based on server versions and configurations. The most important changes include adding a new origin to the CORS configuration and modifying the credential selection logic for various server operations.

CORS configuration update:

* [`cmd/actlabs-hub/main.go`](diffhunk://#diff-7bf50f0d432033660a66d89198850eb7fa9cd97e913af61afb583e28bf57829bL113-R113): Added "https://app.msftactlabs.com" to the list of allowed origins in the CORS configuration.

Credential handling improvements:

* [`internal/repository/server.go`](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL123-R128): Updated multiple functions (`GetClientStorageAccount`, `GetClientStorageAccountKey`, `DestroyAzureContainerGroup`, `IsUserAuthorized`, `IsActlabsAuthorized`, `GetResourceGroupRegion`, `DisableStorageAccountAccessKeys`, `DeleteResourceGroup`, and `DeleteStorageAccount`) to conditionally use `FdpoCredential` instead of `Cred` when the server version is "V3" and `ActlabsHubUseUserAuth` is false. [[1]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL123-R128) [[2]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL182-R192) [[3]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL799-R809) [[4]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL887-R911) [[5]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL953-R965) [[6]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL1070-R1087) [[7]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dR1123-R1140) [[8]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL1153-R1181) [[9]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL1195-R1223)

Logging enhancements:

* [`internal/repository/server.go`](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dR1123-R1140): Added logging statements to the `UpdateStorageAccountAccessKeys` function to provide more detailed information about the operation, including the credentials being used and the status of the access keys. [[1]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dR1123-R1140) [[2]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL1122-R1150) [[3]](diffhunk://#diff-d253b6490550be7a983e03e40a7dbdea4577a4e006feea0e68e48de98b65cd4dL1137-R1165)