### PR TITLE
fix: updating self-host.sh

### DIFF
--- a/scripts/self-host.sh
+++ b/scripts/self-host.sh
@@ -254,7 +254,11 @@ function deploy() {
   export AZURE_SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
   export AUTH_TOKEN_ISS="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0" # The app used by ACTLabs is still in the prod tenant
   export AUTH_TOKEN_AUD="00399ddd-434c-4b8a-84be-d096cff4f494"
-  export ACTLABS_HUB_URL="https://actlabs-hub-capp.redisland-ff4b63ab.eastus.azurecontainerapps.io/"
+  export ACTLABS_HUB_URL="https://actlabs-hub-capp.purplegrass-7409b036.eastus.azurecontainerapps.io/"
+  export ACTLABS_HUB_SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
+  export ACTLABS_HUB_RESOURCE_GROUP_NAME="${RESOURCE_GROUP}"
+  export ACTLABS_HUB_STORAGE_ACCOUNT_NAME="${STORAGE_ACCOUNT_NAME}"
+  export USER_ALIAS="${USER_ALIAS}"
 
   # Start docker container and set environment variables
   log "starting docker container"
@@ -272,7 +276,11 @@ function deploy() {
     -e AUTH_TOKEN_AUD \
     -e AUTH_TOKEN_ISS \
     -e ACTLABS_HUB_URL \
-    --name actlabs -p 8880:80 -v ${HOME}/.azure:/root/.azure ashishvermapu/repro:${TAG}
+    -e ACTLABS_HUB_SUBSCRIPTION_ID \
+    -e ACTLABS_HUB_RESOURCE_GROUP_NAME \
+    -e ACTLABS_HUB_STORAGE_ACCOUNT_NAME \
+    -e USER_ALIAS \
+    --name actlabs -p 8880:80 -v ${HOME}/.azure:/root/.azure ashishvermapu/repro:prod
   if [ $? -ne 0 ]; then
     err "Failed to start docker container"
     exit 1


### PR DESCRIPTION
With the changes to the server, we need additional environment variables and configuration to get a self-hosted version of the server to run correctly. This also locks the image tag in as "prod".